### PR TITLE
Add PQShield

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ A curated list of awesome semiconductor startups.
 * [Pensando](https://pensando.io/)
 * [Perceive](https://perceive.io)
 * [Picocom](https://picocom.com/)
+* [PQShield](https://pqshield.com/)
+	* Hardware co-processors and sub-systems for Post-quantum Cryptography.
 * [PragmatiC](https://www.pragmaticsemi.com/)
 * [proteanTecs](https://www.proteantecs.com/)
 * [Qadric](https://www.quadric.io/)


### PR DESCRIPTION
PQShield is a startup focusing on [post-quantum cryptography](https://csrc.nist.gov/projects/post-quantum-cryptography), and a large part of the business is hardware IP for supporting these new cryptographic algorithms.

Hardware isn't the _only_ part of the business (software and fundamental cryptographic research being the other main arms), but as a member of the hardware team at PQShield, I think we fit well in the spirit of your awesome list!

Please let me know if any more info / rationale is needed.

Cheers,
Ben