### PR TITLE
Fix spelling of Quadric

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@
 |[proteanTecs](https://proteantecs.com) | ANALOG | 2017 | IL |Analytics platform for increasing performance and reliability of electronic systems |
 |[PseudolithIC](https://pseudolithic.com) | MFG | 2019 | US |Heterogeneous integration process for RF applications |
 |[PsiQuantum](https://psiquantum.com) | QUANTUM | 2015 | US |Quantum computers |
-|[Qadric.io](https://quadric.io) | AI | 2016 | US |Edge processing for edge devices |
+|[Quadric.io](https://quadric.io) | AI | 2016 | US |Edge processing for edge devices |
 |[Qualinx](https://qualinx.io) | RF | 2015 | NL |IoT GNSS based tracking and connectivity |
 |[Quilter](https://quilter.ai) | EDA | 2020 | US |AI driven PCB design |
 |[Quintessent](https://quintessent.com) | PHOTONICS | 2019 | US |Optical interconnect |

--- a/startups.csv
+++ b/startups.csv
@@ -145,7 +145,7 @@ Primis,primis.ai,EDA,US,2023,Generative-AI driven hardware design
 proteanTecs,proteantecs.com,ANALOG,IL,2017,Analytics platform for increasing performance and reliability of electronic systems
 PseudolithIC,pseudolithic.com,MFG,US,2019,Heterogeneous integration process for RF applications
 PsiQuantum,psiquantum.com,QUANTUM,US,2015,Quantum computers
-Qadric.io,quadric.io,AI,US,2016,Edge processing for edge devices
+Quadric.io,quadric.io,AI,US,2016,Edge processing for edge devices
 Qualinx,qualinx.io,RF,NL,2015,IoT GNSS based tracking and connectivity
 Quilter,quilter.ai,EDA,US,2020,AI driven PCB design
 Quintessent,quintessent.com,PHOTONICS,US,2019,Optical interconnect


### PR DESCRIPTION
Fix the spelling of Quadric.io in Company column. Website had it correctly.
The sort order does not change.