### PR TITLE
Add some startups

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@
 |[Ferric](https://ferric.com) | ANALOG | 2010 | US |Single-chip power converters |
 |[Finchetto](https://finchetto.com) | PHOTONICS | 2020 | UK |Photonic sensors for quantum computing |
 |[Flex Logix](https://flex-logix.com) | FPGA | 2014 | US |Embedded FPGA IP |
+|[Flow Computing](https://flow-computing.com) | HPC | 2024 | FI |Parallel processing IP |
 |[Flux](https://flux.ai) | EDA | 2019 | US |PCB design tools |
 |[FMC](https://ferroelectric-memory.com) | MFG | 2015 | DE |Ferroelectric non-volatile random access memory technology |
 |[Forefrontrf](https://forefrontrf.com) | RF | 2020 | UK |Wireless communication devices |

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@
 |[RaiderChip](https://raiderchip.ai) | AI | 2024 | ES |AI hardware |
 |[Ramon Space](https://ramon.space) | SPACE | 2004 | IL |Computer system designed for computing in space |
 |[Ranovus](https://ranovus.com) | PHOTONICS | 2012 | CA |Photonics interconnect solutions |
+|[Rapid Photonics](https://rapidphotonics.com) | MFG | 2022 | NL |Photonic IC production |
 |[RapidSilicon](https://rapidsilicon.com) | FPGA | 2021 | US |FPGA devices |
 |[Rebellions](https://rebellions.ai) | AI | 2020 | KR |AI processors |
 |[Recogni](https://recogni.com) | AI | 2017 | US |Visual perception platform for autonomous vehicles |

--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@
 |[Vector Photonics](https://vectorphotonics.co.uk) | PHOTONICS | 2020 | UK |Semiconductor lasers |
 |[Ventana Micro](https://ventanamicro.com) | RISC-V | 2018 | US |RISC-V CPU cores and compute subsystems |
 |[VerifAI](https://verifai.ai) | EDA | 2020 | US |Speeding up Hardware & Software Verification using LLMs & Reinforcement Learning |
+|[Viqthor](https://viqthor.com) | QUANTUM | 2023 | FR |RF, Microwaves, and Photonics applied to Quantum Processing |
 |[Volantis Semiconductor](https://volantissemi.ai) | AI | 2022 | US |AI processors |
 |[VoltAI](https://voltai.com) | EDA | 2022 | US |AI models for semiconductor |
 |[VyperCore](https://vypercore.com) | RISC-V | 2022 | UK |RISC-V processors |

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@
 |[Rain Neuromorphics](https://rain.ai) | AI | 2017 | US |Brain-inspired hardware for AI applications |
 |[RaiderChip](https://raiderchip.ai) | AI | 2024 | ES |AI hardware |
 |[Ramon Space](https://ramon.space) | SPACE | 2004 | IL |Computer system designed for computing in space |
+|[Ranovus](https://ranovus.com) | PHOTONICS | 2012 | CA |Photonics interconnect solutions |
 |[RapidSilicon](https://rapidsilicon.com) | FPGA | 2021 | US |FPGA devices |
 |[Rebellions](https://rebellions.ai) | AI | 2020 | KR |AI processors |
 |[Recogni](https://recogni.com) | AI | 2017 | US |Visual perception platform for autonomous vehicles |

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@
 |[Akhetonics](https://akhetonics.com) | PHOTONICS | 2021 | DE |Optical computing devices |
 |[Alif Semiconductor](https://alifsemi.com) | AI | 2019 | US |Integrated SoC for AI at the edge |
 |[Allspice.io](https://allspice.io) | EDA | 2018 | US |Design platform for streamlined hardware development |
-|[Alpha ICs](https://alphaics.ai) | AI | 2016 | US |AI co-processors for edge devices |
 |[Ambient Scientific](https://ambientscientific.ai) | ANALOG | 2018 | US |Analog in-memory AI processor |
 |[Ampere Computing](https://amperecomputing.com) | HPC | 2017 | US |Cloud native manycore CPUs |
 |[Anabrid](https://anabrid.com) | ANALOG | 2023 | DE |Analog computer on a chip |
@@ -312,6 +311,7 @@
 |---------| ------- | ------ | ------|------|
 |Acacia | IPO | 2016 | 1000 | [Source](https://www.bizjournals.com/boston/news/2016/12/29/the-best-performing-ipo-nationwide-of-2016-is.html) |
 |Agnilux | Google | 2010 | NA | [Source](https://techcrunch.com/2010/04/20/google-agnilux-apple) |
+|Alpha ICs | Shutdown | 2023 | 0 | [Source](https://pitchbook.com/profiles/company/163655-74) |
 |Alphawave | IPO | 2021 | 4300 | [Source](https://www.marketwatch.com/story/chip-maker-alphawave-set-for-4-3-billion-london-ipo-after-shunning-the-nasdaq-11620840007) |
 |Altair Semiconductor | Sony | 2016 | 212 | [Source](https://www.jvpvc.com/case-studies/altair/) |
 |Ambric | Shutdown | 2008 | 0 | [Source](https://www.oregonlive.com/siliconforest/2008/11/ambric_suspends_operation_plan.html) |

--- a/README.md
+++ b/README.md
@@ -150,7 +150,6 @@
 |[Gemesys](https://gemesys.tech) | AI | 2021 | DE |Analog AI processors |
 |[getinstachip](https://getinstachip.com) | EDA | 2024 | US |Intelligent package manager for Verilog |
 |[Gowin](https://gowinsemi.com) | FPGA | 2014 | CN |FPGA chip products |
-|[GrAI Matter Labs](https://graimatterlabs.ai) | AI | 2016 | FR |Programmable neuromorphic computing chips |
 |[Greenwaves](https://greenwaves-technologies.com) | AI | 2014 | FR |Low power edge AI SoCs |
 |[Groq](https://groq.com) | AI | 2016 | US |AI processors |
 |[Gyrfalcon](https://gyrfalcontech.ai) | AI | 2017 | US |AI processors |

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@
 |[VoltAI](https://voltai.com) | EDA | 2022 | US |AI models for semiconductor |
 |[VyperCore](https://vypercore.com) | RISC-V | 2022 | UK |RISC-V processors |
 |[Wave Photonics](https://wavephotonics.com) | PHOTONICS | 2021 | UK |Photonics design platform |
+|[Welinq](https://welinq.fr) | QUANTUM | 2022 | FR |Quantum interconnects |
 |[Xanadu](https://xanadu.ai) | PHOTONICS | 2016 | US |Photonic based quantum computer |
 |[Xscape Photonics](https://xscapephotonics.com) | PHOTONICS | 2022 | US |Photonic communication chips |
 |[Xsight Labs](https://xsightlabs.com) | HPC | 2017 | IL |Chipsets for accelerating data-intensive workloads |

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@
 |[Matx](https://matx.com) | AI | 2022 | US |Platform for AGI |
 |[MangoBoost](https://mangoboost.io) | HPC | 2022 | US |Data processing units for data center |
 |[Memryx](https://memryx.com) | AI | 2019 | US |AI computing platform |
+|[MetisX](https://metix.com) | MEMORY | 2022 | KR |CXL memory solutions |
 |[Mintneuro](https://mintneuro.com) | HEALTH | 2015 | UK |Neural implants |
 |[Mobilint](https://mobilint.com) | AI | 2019 | KR |AI inference accelerators |
 |[Morse Micro](https://morsemicro.com) | RF | 2016 | AU |Low-power Wi-Fi chips |

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@
 |[Alif Semiconductor](https://alifsemi.com) | AI | 2019 | US |Integrated SoC for AI at the edge |
 |[Allspice.io](https://allspice.io) | EDA | 2018 | US |Design platform for streamlined hardware development |
 |[Alpha ICs](https://alphaics.ai) | AI | 2016 | US |AI co-processors for edge devices |
+|[Ambient Scientific](https://ambientscientific.ai) | ANALOG | 2018 | US |Analog in-memory AI processor |
 |[Ampere Computing](https://amperecomputing.com) | HPC | 2017 | US |Cloud native manycore CPUs |
 |[Anabrid](https://anabrid.com) | ANALOG | 2023 | DE |Analog computer on a chip |
 |[Analog Inference](https://analog-inference.com) | AI | 2018 | US |Analog in-memory AI inference accelerators |

--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@
 |[Usound](https://usound.com) | MEMS | 2012 | AU |Sound solutions based on MEMS technology |
 |[Vaire Computing](https://vaire.co) | ANALOG | 2021 | UK |Near zero energy computing |
 |[Vayyar](https://vayyar.com) | SENSORS | 2011 | IL |High resolution image sensors |
+|[Vector Photonics](https://vectorphotonics.co.uk) | PHOTONICS | 2020 | UK |Semiconductor lasers |
 |[Ventana Micro](https://ventanamicro.com) | RISC-V | 2018 | US |RISC-V CPU cores and compute subsystems |
 |[VerifAI](https://verifai.ai) | EDA | 2020 | US |Speeding up Hardware & Software Verification using LLMs & Reinforcement Learning |
 |[Volantis Semiconductor](https://volantissemi.ai) | AI | 2022 | US |AI processors |

--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@
 | Company |  Exit   | Year   | Value($M) | Link |
 |---------| ------- | ------ | ------|------|
 |Acacia | IPO | 2016 | 1000 | [Source](https://www.bizjournals.com/boston/news/2016/12/29/the-best-performing-ipo-nationwide-of-2016-is.html) |
+|Aeluma | IPO | 2023 | 6 | [Source](https://www.aeluma.com/news-media/press-releases/detail/28/aeluma-inc-closes-6-million-oversubscribed-common-stock) |
 |Agnilux | Google | 2010 | NA | [Source](https://techcrunch.com/2010/04/20/google-agnilux-apple) |
 |Alpha ICs | Shutdown | 2023 | 0 | [Source](https://pitchbook.com/profiles/company/163655-74) |
 |Alphawave | IPO | 2021 | 4300 | [Source](https://www.marketwatch.com/story/chip-maker-alphawave-set-for-4-3-billion-london-ipo-after-shunning-the-nasdaq-11620840007) |

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@
 |[Lemurian Labs](https://lemurianlabs.com) | AI | 2018 | CA |AI computing platform |
 |[Light Solver](https://lightsolver.com) | PHOTONICS | 2019 | IL |Optical computing platform |
 |[Lightelligence](https://lightelligence.ai) | PHOTONICS | 2017 | US |Optical computing platform |
+|[Lightium](https://lightium.co) | MFG | 2023 | CH |Photonics foundry |
 |[Lighton](https://lighton.ai) | PHOTONICS | 2015 | FR |Optical computing platform |
 |[Lightmatter](https://lightmatter.co) | PHOTONICS | 2017 | US |Optical computing platform |
 |[Literal Labs](https://Literal-labs.ai) | AI | 2023 | UK |Explainable AI using Tsetlin machines |

--- a/alumni.csv
+++ b/alumni.csv
@@ -1,6 +1,7 @@
 Company,Exit,Year,Value($M),Link
 Acacia,IPO,2016,1000,https://www.bizjournals.com/boston/news/2016/12/29/the-best-performing-ipo-nationwide-of-2016-is.html
 Agnilux,Google,2010,NA,https://techcrunch.com/2010/04/20/google-agnilux-apple
+Alpha ICs,Shutdown,2023,0,https://pitchbook.com/profiles/company/163655-74
 Alphawave,IPO,2021,4300,https://www.marketwatch.com/story/chip-maker-alphawave-set-for-4-3-billion-london-ipo-after-shunning-the-nasdaq-11620840007
 Altair Semiconductor,Sony,2016,212,https://www.jvpvc.com/case-studies/altair/
 Ambric,Shutdown,2008,0,https://www.oregonlive.com/siliconforest/2008/11/ambric_suspends_operation_plan.html

--- a/alumni.csv
+++ b/alumni.csv
@@ -1,5 +1,6 @@
 Company,Exit,Year,Value($M),Link
 Acacia,IPO,2016,1000,https://www.bizjournals.com/boston/news/2016/12/29/the-best-performing-ipo-nationwide-of-2016-is.html
+Aeluma,IPO,2023,6,https://www.aeluma.com/news-media/press-releases/detail/28/aeluma-inc-closes-6-million-oversubscribed-common-stock
 Agnilux,Google,2010,NA,https://techcrunch.com/2010/04/20/google-agnilux-apple
 Alpha ICs,Shutdown,2023,0,https://pitchbook.com/profiles/company/163655-74
 Alphawave,IPO,2021,4300,https://www.marketwatch.com/story/chip-maker-alphawave-set-for-4-3-billion-london-ipo-after-shunning-the-nasdaq-11620840007

--- a/startups.csv
+++ b/startups.csv
@@ -9,6 +9,7 @@ Akhetonics,akhetonics.com,PHOTONICS,DE,2021,Optical computing devices
 Alif Semiconductor,alifsemi.com,AI,US,2019,Integrated SoC for AI at the edge
 Allspice.io,allspice.io,EDA,US,2018,Design platform for streamlined hardware development
 Alpha ICs,alphaics.ai,AI,US,2016,AI co-processors for edge devices
+Ambient Scientific,ambientscientific.ai,ANALOG,US,2018,Analog in-memory AI processor
 Ampere Computing,amperecomputing.com,HPC,US,2017,Cloud native manycore CPUs
 Anabrid,anabrid.com,ANALOG,DE,2023,Analog computer on a chip
 Analog Inference,analog-inference.com,AI,US,2018,Analog in-memory AI inference accelerators

--- a/startups.csv
+++ b/startups.csv
@@ -8,7 +8,6 @@ Akeana,akeana.com,RISC-V,US,2021,RISC-V CPU and System IP
 Akhetonics,akhetonics.com,PHOTONICS,DE,2021,Optical computing devices
 Alif Semiconductor,alifsemi.com,AI,US,2019,Integrated SoC for AI at the edge
 Allspice.io,allspice.io,EDA,US,2018,Design platform for streamlined hardware development
-Alpha ICs,alphaics.ai,AI,US,2016,AI co-processors for edge devices
 Ambient Scientific,ambientscientific.ai,ANALOG,US,2018,Analog in-memory AI processor
 Ampere Computing,amperecomputing.com,HPC,US,2017,Cloud native manycore CPUs
 Anabrid,anabrid.com,ANALOG,DE,2023,Analog computer on a chip

--- a/startups.csv
+++ b/startups.csv
@@ -175,6 +175,7 @@ Raaam,Raaam-tech.com,MEMORY,IL,2021,High capacity memory technology
 Rain Neuromorphics,rain.ai,AI,US,2017,Brain-inspired hardware for AI applications
 RaiderChip,raiderchip.ai,AI,ES,2024,AI hardware
 Ramon Space,ramon.space,SPACE,IL,2004,Computer system designed for computing in space
+Ranovus,ranovus.com,PHOTONICS,CA,2012,Photonics interconnect solutions
 RapidSilicon,rapidsilicon.com,FPGA,US,2021,FPGA devices
 Rebellions,rebellions.ai,AI,KR,2020,AI processors
 Recogni,recogni.com,AI,US,2017,Visual perception platform for autonomous vehicles

--- a/startups.csv
+++ b/startups.csv
@@ -176,6 +176,7 @@ Rain Neuromorphics,rain.ai,AI,US,2017,Brain-inspired hardware for AI application
 RaiderChip,raiderchip.ai,AI,ES,2024,AI hardware
 Ramon Space,ramon.space,SPACE,IL,2004,Computer system designed for computing in space
 Ranovus,ranovus.com,PHOTONICS,CA,2012,Photonics interconnect solutions
+Rapid Photonics,rapidphotonics.com,MFG,NL,2022,Photonic IC production
 RapidSilicon,rapidsilicon.com,FPGA,US,2021,FPGA devices
 Rebellions,rebellions.ai,AI,KR,2020,AI processors
 Recogni,recogni.com,AI,US,2017,Visual perception platform for autonomous vehicles

--- a/startups.csv
+++ b/startups.csv
@@ -115,6 +115,7 @@ Krutrim,olakrutrim.com,AI,IN,2023,AI hardware
 Lemurian Labs,lemurianlabs.com,AI,CA,2018,AI computing platform
 Light Solver,lightsolver.com,PHOTONICS,IL,2019,Optical computing platform
 Lightelligence,lightelligence.ai,PHOTONICS,US,2017,Optical computing platform
+Lightium,lightium.co,MFG,CH,2023,Photonics foundry
 Lighton,lighton.ai,PHOTONICS,FR,2015,Optical computing platform
 Lightmatter,lightmatter.co,PHOTONICS,US,2017,Optical computing platform
 Literal Labs,Literal-labs.ai,AI,UK,2023,Explainable AI using Tsetlin machines

--- a/startups.csv
+++ b/startups.csv
@@ -236,6 +236,7 @@ Volantis Semiconductor,volantissemi.ai,AI,US,2022,AI processors
 VoltAI,voltai.com,EDA,US,2022,AI models for semiconductor
 VyperCore,vypercore.com,RISC-V,UK,2022,RISC-V processors
 Wave Photonics,wavephotonics.com,PHOTONICS,UK,2021,Photonics design platform
+Welinq,welinq.fr,QUANTUM,FR,2022,Quantum interconnects
 Xanadu,xanadu.ai,PHOTONICS,US,2016,Photonic based quantum computer
 Xscape Photonics,xscapephotonics.com,PHOTONICS,US,2022,Photonic communication chips
 Xsight Labs,xsightlabs.com,HPC,IL,2017,Chipsets for accelerating data-intensive workloads

--- a/startups.csv
+++ b/startups.csv
@@ -91,7 +91,6 @@ Generation Alpha Transistor,generation-alpha-transistor.com,EDA,US,2024,Circuit 
 Gemesys,gemesys.tech,AI,DE,2021,Analog AI processors
 getinstachip,getinstachip.com,EDA,US,2024,Intelligent package manager for Verilog
 Gowin,gowinsemi.com,FPGA,CN,2014,FPGA chip products
-GrAI Matter Labs,graimatterlabs.ai,AI,FR,2016,Programmable neuromorphic computing chips
 Greenwaves,greenwaves-technologies.com,AI,FR,2014,Low power edge AI SoCs
 Groq,groq.com,AI,US,2016,AI processors
 Gyrfalcon,gyrfalcontech.ai,AI,US,2017,AI processors

--- a/startups.csv
+++ b/startups.csv
@@ -231,6 +231,7 @@ Vayyar,vayyar.com,SENSORS,IL,2011,High resolution image sensors
 Vector Photonics,vectorphotonics.co.uk,PHOTONICS,UK,2020,Semiconductor lasers
 Ventana Micro,ventanamicro.com,RISC-V,US,2018,RISC-V CPU cores and compute subsystems
 VerifAI,verifai.ai,EDA,US,2020,Speeding up Hardware & Software Verification using LLMs & Reinforcement Learning
+Viqthor,viqthor.com,QUANTUM,FR,2023,"RF, Microwaves, and Photonics applied to Quantum Processing"
 Volantis Semiconductor,volantissemi.ai,AI,US,2022,AI processors
 VoltAI,voltai.com,EDA,US,2022,AI models for semiconductor
 VyperCore,vypercore.com,RISC-V,UK,2022,RISC-V processors

--- a/startups.csv
+++ b/startups.csv
@@ -228,6 +228,7 @@ Upmem,upmem.com,AI,FR,2015,In memory processing devices for big data and AI
 Usound,usound.com,MEMS,AU,2012,Sound solutions based on MEMS technology
 Vaire Computing,vaire.co,ANALOG,UK,2021,Near zero energy computing
 Vayyar,vayyar.com,SENSORS,IL,2011,High resolution image sensors
+Vector Photonics,vectorphotonics.co.uk,PHOTONICS,UK,2020,Semiconductor lasers
 Ventana Micro,ventanamicro.com,RISC-V,US,2018,RISC-V CPU cores and compute subsystems
 VerifAI,verifai.ai,EDA,US,2020,Speeding up Hardware & Software Verification using LLMs & Reinforcement Learning
 Volantis Semiconductor,volantissemi.ai,AI,US,2022,AI processors

--- a/startups.csv
+++ b/startups.csv
@@ -123,6 +123,7 @@ Luminous Computing,luminous.com,PHOTONICS,US,2018,Optical computing platform
 Matx,matx.com,AI,US,2022,Platform for AGI
 MangoBoost,mangoboost.io,HPC,US,2022,Data processing units for data center
 Memryx,memryx.com,AI,US,2019,AI computing platform
+MetisX,metix.com,MEMORY,KR,2022,CXL memory solutions
 Mintneuro,mintneuro.com,HEALTH,UK,2015,Neural implants
 Mobilint,mobilint.com,AI,KR,2019,AI inference accelerators
 Morse Micro,morsemicro.com,RF,AU,2016,Low-power Wi-Fi chips

--- a/startups.csv
+++ b/startups.csv
@@ -82,6 +82,7 @@ Falcomm ,myfalcomm.com,RF,US,2021,Solid state power amplifiers
 Ferric,ferric.com,ANALOG,US,2010,Single-chip power converters
 Finchetto,finchetto.com,PHOTONICS,UK,2020,Photonic sensors for quantum computing
 Flex Logix,flex-logix.com,FPGA,US,2014,Embedded FPGA IP
+Flow Computing,flow-computing.com,HPC,FI,2024,Parallel processing IP
 Flux,flux.ai,EDA,US,2019,PCB design tools
 FMC,ferroelectric-memory.com,MFG,DE,2015,Ferroelectric non-volatile random access memory technology
 Forefrontrf,forefrontrf.com,RF,UK,2020,Wireless communication devices


### PR DESCRIPTION
Clean up GrAI Matter Labs (alumni).

Move Alpha ICs to alumni (#118).

Add startups:
* Ambient Scientific
* Flow Computing
* Lightium
* MetisX
* RANOVUS
* Rapid Photonics
* Vector Photonics
* Viqthor
* Welinq

Add alumni:
* Aeluma (#120)