### PR TITLE
ENH: added insightness, ACP, and Argus Space

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@
 |[Anello](https://anellophotonics.com) | PHOTONICS | 2018 | US |Photonic based gyroscopes for navigation |
 |[Aniah](https://aniah.fr) | EDA | 2019 | FR |Circuit analysis software |
 |[Applied Brain Research](https://appliedbrainresearch.com) | AI | 2013 | CA |AI solutions for edge devices |
+|[Argus Space](https://argus-space.ch) | RF | 2024 | CH |Satcomm telecommunications and radar |
 |[Aspinity](https://aspinity.com) | AI | 2015 | US |Analog in-memory AI inference accelerators |
 |[Astrus](https://astrus.ai) | EDA | 2022 | CA |AI platform designed to automate microchip design |
 |[Atlantic Quantum](https://atlantic-quantum.com) | QUANTUM | 2022 | US |Scalable quantum computers |
@@ -335,6 +336,7 @@
 | Company |  Exit   | Year   | Value($M) | Link |
 |---------| ------- | ------ | ------|------|
 |Acacia | IPO | 2016 | 1000 | [Source](https://www.bizjournals.com/boston/news/2016/12/29/the-best-performing-ipo-nationwide-of-2016-is.html) |
+|Advanced Circuit Pursuit | Sequans | 2025 | NA | [Source](https://www.walderwyss.com/en/news/2025-01-28_sequans-acquires-acp-advanced-circuit-pursuit-ag) |
 |Aeluma | IPO | 2023 | 6 | [Source](https://www.aeluma.com/news-media/press-releases/detail/28/aeluma-inc-closes-6-million-oversubscribed-common-stock) |
 |Agnilux | Google | 2010 | NA | [Source](https://techcrunch.com/2010/04/20/google-agnilux-apple) |
 |Alpha ICs | Shutdown | 2023 | 0 | [Source](https://pitchbook.com/profiles/company/163655-74) |
@@ -371,6 +373,7 @@
 |Indie Semiconductor | SPAC | 2020 | 1400 | [Source](https://www.marketwatch.com/story/indie-semiconductor-to-go-public-through-spac-buyout-deal-that-values-company-at-14-billion-2020-12-15) |
 |Innovium | Marvell | 2021 | 1100 | [Source](https://techcrunch.com/2021/08/03/marvell-nabs-innovium-for-1-1b-as-it-delves-deeper-into-cloud-ethernet-switches/) |
 |Innoviz | SPAC | 2021 | 371 | [Source](https://www.prnewswire.com/news-releases/innoviz-technologies-and-collective-growth-corporation-announce-closing-of-business-combination-301262031.html) |
+|Insightness | Sony | 2019 | NA | [Source](https://ethz.ch/en/industry/entrepreneurship/explore-startup-portraits-and-success-stories/exits/insightness.html) |
 |Kalray | IPO | 2018 | 100 | [Source](https://www.euronext.com/en/about/media/euronext-press-releases/kalray-sintroduit-sur-euronext-growth) |
 |Kinara | NXP | 2025 | 307 | [Source](https://www.nxp.com/company/about-nxp/newsroom/NW-AI-PR-2025) |
 |Lucata | Shutdown | 2024 | NA | [Source](https://www.linkedin.com/posts/marty-deneroff-2a554_sadly-lucata-emu-technology-ceased-operations-activity-7168985090331500544-xy_D) |

--- a/alumni.csv
+++ b/alumni.csv
@@ -1,5 +1,6 @@
 Company,Exit,Year,Value($M),Link
 Acacia,IPO,2016,1000,https://www.bizjournals.com/boston/news/2016/12/29/the-best-performing-ipo-nationwide-of-2016-is.html
+Advanced Circuit Pursuit,Sequans,2025,NA,https://www.walderwyss.com/en/news/2025-01-28_sequans-acquires-acp-advanced-circuit-pursuit-ag
 Aeluma,IPO,2023,6,https://www.aeluma.com/news-media/press-releases/detail/28/aeluma-inc-closes-6-million-oversubscribed-common-stock
 Agnilux,Google,2010,NA,https://techcrunch.com/2010/04/20/google-agnilux-apple
 Alpha ICs,Shutdown,2023,0,https://pitchbook.com/profiles/company/163655-74
@@ -36,6 +37,7 @@ Imperas,Synopsys,2023,NA,https://www.design-reuse.com/news/55442/synopsys-impera
 Indie Semiconductor,SPAC,2020,1400,https://www.marketwatch.com/story/indie-semiconductor-to-go-public-through-spac-buyout-deal-that-values-company-at-14-billion-2020-12-15
 Innovium,Marvell,2021,1100,https://techcrunch.com/2021/08/03/marvell-nabs-innovium-for-1-1b-as-it-delves-deeper-into-cloud-ethernet-switches/
 Innoviz,SPAC,2021,371,https://www.prnewswire.com/news-releases/innoviz-technologies-and-collective-growth-corporation-announce-closing-of-business-combination-301262031.html
+Insightness,Sony,2019,NA,https://ethz.ch/en/industry/entrepreneurship/explore-startup-portraits-and-success-stories/exits/insightness.html
 Kalray,IPO,2018,100,https://www.euronext.com/en/about/media/euronext-press-releases/kalray-sintroduit-sur-euronext-growth
 Kinara,NXP,2025,307,https://www.nxp.com/company/about-nxp/newsroom/NW-AI-PR-2025
 Lucata,Shutdown,2024,NA,https://www.linkedin.com/posts/marty-deneroff-2a554_sadly-lucata-emu-technology-ceased-operations-activity-7168985090331500544-xy_D

--- a/startups.csv
+++ b/startups.csv
@@ -18,6 +18,7 @@ Andapt,andapt.com,ANALOG,IE,2014,Programmable power management ICs
 Anello,anellophotonics.com,PHOTONICS,US,2018,Photonic based gyroscopes for navigation
 Aniah,aniah.fr,EDA,FR,2019,Circuit analysis software
 Applied Brain Research,appliedbrainresearch.com,AI,CA,2013,AI solutions for edge devices
+Argus Space,argus-space.ch,RF,CH,2024,Satcomm telecommunications and radar
 Aspinity,aspinity.com,AI,US,2015,Analog in-memory AI inference accelerators
 Astrus,astrus.ai,EDA,CA,2022,AI platform designed to automate microchip design
 Atlantic Quantum,atlantic-quantum.com,QUANTUM,US,2022,Scalable quantum computers


### PR DESCRIPTION
Added several CH-based startups.
Insightness sold to Sony in 2019
ACP sold to Sequance in 2025
Argus Space funded in 2024