### PR TITLE
Add 8 startups, remove 7 startups, fix 8 rows in startups, move 4 to alumni, fix 2 rows in alumni

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,16 +110,15 @@ BibTeX:
 |[Atlantic Quantum](https://atlantic-quantum.com) | QUANTUM | 2022 | US |Scalable quantum computers |
 |[Atmosic](https://atmosic.com) | RF | 2016 | US |Battery free wireless devices |
 |[Atoms AI](https://atomsai.net) | EDA | 2024 | US |AI driven verification |
+|[Aule Technologies](https://auletechnologies.com) | EDA | 2022 | US |AI/physics based design platform |
 |[Avicena](https://avicena.tech) | PHOTONICS | 2019 | US |Optical uLed interconnect technology |
 |[Axelera](https://axelera.ai) | AI | 2021 | NL |Low power AI edge processors |
-|[Aule Technologies](https://auletechnologies.com) | EDA | 2022 | US |AI/physics based design platform |
 |[Ayar Labs](https://ayarlabs.com) | PHOTONICS | 2015 | US |Electronic-photonic communication chip sets |
-|[Azimuth AI](https://Azimuth-ai.com) | ASIC | 2023 | US |Edge AI ASICs |
+|[Azimuth AI](https://azimuth-ai.com) | ASIC | 2023 | US |Edge AI ASICs |
 |[Baya Systems](https://bayasystems.com) | CHIPLETS | 2023 | US |Chiplet Based Semiconductor Design |
-|[Beacon Photonics](https://beaconphotonics) | PHOTONICS | 2023 | US |Integrated photonics platform |
+|[Beacon Photonics](https://beaconphotonics.com) | PHOTONICS | 2023 | US |Integrated photonics platform |
 |[Beam](https://beamshaping.io) | RF | 2015 | IL |Phased array antennas |
 |[Belfort](https://belfortlabs.com) | SECURITY | 2025 | BE |Hardware for encrypted compute (FHE) |
-|[Build4Sim Inc](https://build4sim.com) | EDA |  accelerating Spice simulation | 2025 |None |
 |[Black Semiconductor](https://blacksemiconductor.de) | MFG | 2021 | DE |Graphene electronics/photonics translators |
 |[Blueshift Memory](https://blueshiftmemory.com) | MEMORY | 2016 | UK |High performance memory centric architecture |
 |[Bluespec](https://bluespec.com) | RISC-V | 2003 | US |RISC-V IP and System Development Tools |
@@ -128,23 +127,25 @@ BibTeX:
 |[BoolSi](https://boolsi.com) | EDA | 2023 | US |Generate RTL from any code base, in any language |
 |[bos semiconductors](https://bos-semi.com) | ASIC | 2022 | KR |Automotive ASICs |
 |[Bronco AI](https://bronco.ai) | EDA | 2022 | US |AI tools for chip development |
-|[cassia.ai](https://cassia.ai) | AI | 2021 | US |AI Hardware IP |
+|[Build4Sim Inc](https://build4sim.com) | EDA | 2025 | US |Accelerating Spice simulation |
 |[cadlab.io](https://cadlab.io) | EDA | 2015 | US |Collaboration tools for PCB design |
 |[Cadstrom](https://cadstrom.io) | EDA | 2023 | CA |AI based PCB design |
+|[cassia.ai](https://cassia.ai) | AI | 2021 | US |AI Hardware IP |
 |[Celera](https://celeratechnologies.com) | EDA | 2018 | US |Automated analog/mixed-signal IC development tool |
+|[Celero Communications](https://celero.inc) | NETWORKING | 2024 | US |Coherent DSP platform for high-bandwidth low-power optical connectivity |
 |[Celestial AI](https://celestial.ai) | PHOTONICS | 2020 | US |Photonic fabric optical interconnect technology |
 |[Cellium](https://cellium.net) | RF | 2016 | IL |Wireless infrastructure for indoor connectivity |
 |[Celtro](https://celtro.de) | HEALTH | 2019 | DE |Energy harvesting implantable medical devices |
 |[Celus](https://celus.io) | EDA | 2016 | DE |PCB design tools |
-|[Cerebras](https://cerebras.net) | HPC | 2016 | US |Wafer scale processors |
 |[Ceremorphic](https://ceremorphic.com) | HPC | 2020 | US |Analog computing architecture |
 |[Cerfe Labs](https://cerfelabs.com) | MFG | 2020 | US |Electronics materials and device research |
-|[Chipmind](https://chipmind.ai) | EDA | 2024 | CH |Agentic chip design |
+|[ChipAgents](https://chipagents.ai) | EDA | 2024 | US |Agentic AI chip design environment |
 |[Chipflow](https://chipflow.io) | ASIC | 2021 | UK |ASIC design platform |
 |[Chipletz](https://chipletz.com) | CHIPLETS | 2021 | US |Smart substrate for chiplet integration |
+|[Chipmind](https://chipmind.ai) | EDA | 2024 | CH |Agentic chip design |
 |[Chipstack](https://chipstack.com) | EDA | 2023 | US |AI based chip design methodology |
 |[Circuit Mind](https://circuitmind.io) | EDA | 2018 | UK |PCB design tools |
-|[CircuitLeap.ai](https://circuitleap.ai) | EDA | 2024 | Portugal |Automated analog design with GPU and AI |
+|[CircuitLeap.ai](https://circuitleap.ai) | EDA | 2024 | PT |Automated analog design with GPU and AI |
 |[Classiq](https://classiq.io) | EDA | 2020 | IL |Quantum computing software |
 |[Codasip](https://codasip.com) | RISC-V | 2014 | DE |Supplier of RISC-V IP cores |
 |[Cognichip](https://cognichip.ai) | EDA | 2024 | US |AI platform for chip design |
@@ -157,20 +158,19 @@ BibTeX:
 |[DeepX](https://deepx.ai) | AI | 2018 | KR |AI processors |
 |[DeGirum](https://degirum.ai) | AI | 2017 | US |AI platform for edge applications |
 |[Denpaflux](https://denpaflux.com) | EDA | 2022 | DE |EMC analysis platform for design engineering teams |
-|[Diode Computers](https://diode.computer) | EDA | 2024 | US |AI based PCB design |
 |[Dfiant](https://dfiant.works) | EDA | 2022 | US |Chip design tools |
+|[Diode Computers](https://diode.computer) | EDA | 2024 | US |AI based PCB design |
 |[Dnotitia](https://dnotitia.com) | AI | 2023 | KR |AI processors |
 |[Dover](https://dovermicrosystems.com) | SECURITY | 2017 | US |SoC security IP |
-|[Dust Photonics](https://dustphotonics.com) | PHOTONICS | 2017 | IL |Small footprint integrate photonics transceivers |
 |[DreamBig](https://dreambigsemi.com) | CHIPLETS | 2019 | US |Chiplet based ASIC platform |
+|[Dust Photonics](https://dustphotonics.com) | PHOTONICS | 2017 | IL |Small footprint integrate photonics transceivers |
 |[EdgeCortix](https://edgecortix.com) | AI | 2019 | US |AI accelerators for edge devices |
 |[EdgeQ](https://edgeq.io) | RF | 2018 | US |Base station-on-a-chip |
-|[Efinix](https://efinixinc.com) | FPGA | 2012 | US |Programmable FPGA products |
 |[Efficient Computer](https://efficient.computer) | HPC | 2022 | US |Energy efficient general-purpose processor |
+|[Efinix](https://efinixinc.com) | FPGA | 2012 | US |Programmable FPGA products |
 |[Eliyan](https://eliyan.com) | CHIPLETS | 2021 | US |Interconnect technology |
 |[EnCharge AI](https://enchargeai.com) | AI | 2021 | US |AI processing platform |
 |[Enlightra](https://enlightra.com) | PHOTONICS | 2017 | US |Optical microresonator technology |
-|[Enosemi](https://enosemi.com) | PHOTONICS | 2023 | US |Photonics subsystems |
 |[enzzo](https://enzzo.ai) | EDA | 2024 | US |AI driven hardware development |
 |[Equal1](https://equal1.com) | QUANTUM | 2017 | IE |Silicon spin qubits for scalable quantum computing |
 |[Eridan](https://eridan.io) | RF | 2013 | US |RF front end for for wireless telecommunications |
@@ -215,25 +215,25 @@ BibTeX:
 |[Jitx](https://jitx.com) | EDA | 2016 | US |PCB design tools |
 |[Kandou](https://kandou.com) | NETWORKING | 2011 | CH |Chip-to-chip connectivity solutions |
 |[Kepler Computing](https://keplercompute.com) | HPC | 2018 | US |Stealth |
-|[Kittycad](https://zoo.dev) | EDA | 2021 | US |AI driven CAD |
 |[Keysom](https://keysom.io) | RISC-V | 2022 | FR |RISC-V design platform |
+|[Kittycad](https://zoo.dev) | EDA | 2021 | US |AI driven CAD |
 |[Kneron](https://kneron.com) | AI | 2015 | US |Edge AI devices |
 |[Krutrim](https://olakrutrim.com) | AI | 2023 | IN |AI hardware |
 |[Lemurian Labs](https://lemurianlabs.com) | AI | 2018 | CA |AI computing platform |
 |[Light Solver](https://lightsolver.com) | PHOTONICS | 2019 | IL |Optical computing platform |
 |[Light Trace Photonics](https://ltphotonics.co.uk) | PHOTONICS | 2021 | UK |Platform for rapid photonic product development |
-|[Lightelligence](https://lightelligence.ai) | PHOTONICS | 2017 | US |Optical computing platform |
 |[Lightium](https://lightium.co) | MFG | 2023 | CH |Photonics foundry |
 |[Lightmatter](https://lightmatter.co) | PHOTONICS | 2017 | US |Optical computing platform |
-|[Lighton](https://lighton.ai) | PHOTONICS | 2015 | FR |Optical computing platform |
-|[Literal Labs](https://Literal-labs.ai) | AI | 2023 | UK |Explainable AI using Tsetlin machines |
 |[Linctrinsic](https://lintrinsicsemi.com) | RF | 2021 | US |Fast RF switches |
 |[Linque](https://linque.eu) | PHOTONICS | 2023 | DE |Optical computing  |
+|[Literal Labs](https://Literal-labs.ai) | AI | 2023 | UK |Explainable AI using Tsetlin machines |
 |[Lubis EDA](https://Lubis-eda.com) | EDA | 2021 | DE |Cloud based formal verification platform |
 |[Lumai](https://luma.ai) | PHOTONICS | 2021 | UK |3D optical computing |
 |[Luminous Computing](https://luminous.com) | PHOTONICS | 2018 | US |Optical computing platform |
 |[Lumotive](https://lumotive.com) | PHOTONICS | 2017 | US |Optical beam forming sensors |
 |[Lyte AI](https://lyte.ai) | AI | 2021 | US |Perception layer for physical AI |
+|[Magics Technologies](https://magics.tech) | SPACE | 2015 | BE |Radiation-hardened ICs for space systems and nuclear infrastructure |
+|[Maieutic Semiconductors](https://maieuticsemi.com) | EDA | 2025 | IN |Generative AI copilot for analog chip design |
 |[Majestic Labs](https://majestic-labs.ai) | AI | 2023 | IL |AI procesor |
 |[MangoBoost](https://mangoboost.io) | HPC | 2022 | US |Data processing units for data center |
 |[Matx](https://matx.com) | AI | 2022 | US |Platform for AGI |
@@ -243,14 +243,15 @@ BibTeX:
 |[Mobilint](https://mobilint.com) | AI | 2019 | KR |AI inference accelerators |
 |[Morphing Machines](https://morphing.in) | HPC | 2006 | IN |Reconfigurable processors |
 |[Morse Micro](https://morsemicro.com) | RF | 2016 | AU |Low-power Wi-Fi chips |
-|[Mosaic SoC](https://mosaic-soc.com/) | ASIC | 2024 | CH |Specialized chips designed for AR glasses |
+|[Mosaic SoC](https://mosaic-soc.com) | ASIC | 2024 | CH |Specialized chips designed for AR glasses |
 |[Motivo](https://motivo.ai) | EDA | 2015 | US |Explainable AI and ML for chip design optimization |
+|[Movandi](https://movandi.com) | RF | 2016 | US |RF chipsets |
 |[Movellus](https://movellus.com) | ANALOG | 2014 | US |Clock distribution IP |
 |[Mythic](https://mythic-ai.com) | AI | 2012 | US |Analog ML accelerators |
 |[MZ Technologies](https://genioevo.com) | EDA | 2014 | IT |EDA solutions for advanced packaging |
 |[Nanopower](https://nanopowersemi.com) | ANALOG | 2017 | NO |Smart power management ICs |
 |[NcodiN](https://ncodin.com) | PHOTONICS | 2023 | FR |Optical interposers |
-|[Neologic](https://neologic.com) | MFG | 2021 | IL |Quasi-CMOS transistor technology |
+|[Neologic](https://neologicvlsi.com) | MFG | 2021 | IL |Quasi-CMOS transistor technology |
 |[Netrasemi](https://netrasemi.com) | AI | 2020 | IN |AI Hardware chips |
 |[Neureality](https://neureality.ai) | AI | 2019 | IL |Purpose-built AI-centric architecture |
 |[NeuroBlade](https://neuroblade.com) | AI | 2018 | IL |Accelerators for high throughput data analytics |
@@ -277,9 +278,9 @@ BibTeX:
 |[par.tcl](https://partcl.com) | EDA | 2024 | US |Physics based eda tools |
 |[persimmons](https://persimmons.ai) | AI | 2023 | US |Flexible, low-power generative AI inference system  |
 |[Phanofi](https://phanofi.com) | PHOTONICS | 2022 | DK |Optical transceivers for data centers & HPC |
-|[Pharrowtech](https://pharrowtech.com) | RF | 2018 | BE |RF ICs for high speed wireless links |
 |[Phoenix Semiconductor](https://phoenixsemicorp.com) | ASIC | 2023 | US |Drop in replacements for discontinued devices |
 |[Picocom](https://picocom.com) | RF | 2019 | UK |Semiconductor products for 5G infrastructure |
+|[Piris Labs](https://pirislabs.io) | AI | 2025 | US |Optical inference engine |
 |[Plaid Semiconductor](https://plaidsemi.com) | CHIPLETS | 2023 | US |Interposers for chiplet integration |
 |[Pliops](https://pliops.com) | HPC | 2017 | IL |Scalable data handling/acceleration |
 |[PointCloud](https://point.cloud) | SENSORS | 2017 | US |4D imaging sensors |
@@ -290,7 +291,6 @@ BibTeX:
 |[Precision Innovations](https://precisioninno.com) | EDA | 2019 | US |Developing and supporting OpenROAD |
 |[Primemas](https://primemas.com) | CHIPLETS | 2023 | US |Platform for rapid SoC system development |
 |[Primis](https://primis.ai) | EDA | 2023 | US |Generative-AI driven hardware design |
-|[Piris Labs](https://pirislabs.io/) | AI | 2025 | US |Optical inference engine |
 |[proteanTecs](https://proteantecs.com) | ANALOG | 2017 | IL |Analytics platform for advanced chip design |
 |[PseudolithIC](https://pseudolithic.com) | MFG | 2019 | US |Integration process for RF applications |
 |[PsiQuantum](https://psiquantum.com) | QUANTUM | 2015 | US |Quantum computers |
@@ -299,7 +299,7 @@ BibTeX:
 |[Qruise](https://qruise.com) | QUANTUM | 2021 | DE |Design and verification of quantum systems |
 |[Quadric.io](https://quadric.io) | AI | 2016 | US |Edge processing for edge devices |
 |[Qualinx](https://qualinx.io) | RF | 2015 | NL |IoT GNSS based tracking and connectivity |
-|[Quantum Motion](https://quantummmotion.tech) | QUANTUM | 2017 | UK |Scalable quantum computer architectural technology |
+|[Quantum Motion](https://quantummotion.com) | QUANTUM | 2017 | UK |Scalable quantum computer architectural technology |
 |[Quera Computing](https://quera.com) | QUANTUM | 2018 | US |Neutral atom based quantum computers |
 |[Quilter](https://quilter.ai) | EDA | 2020 | US |AI driven PCB design |
 |[Quintessent](https://quintessent.com) | PHOTONICS | 2019 | US |Optical interconnect |
@@ -315,6 +315,7 @@ BibTeX:
 |[RED Semiconductor](https://redsemiconductor.com) | HPC | 2021 | UK |Processor technology |
 |[Redwood EDA](https://redwoodeda.com) | EDA | 2015 | US |Transaction level hardware design platform |
 |[Retym](https://retym.com) | AI | 2021 | US |Stealth |
+|[Ricursive Intelligence](https://ricursive.com) | EDA | 2025 | US |AI models to automate all stages of chip design and verification |
 |[RISE](https://Rise-da.com) | EDA | 2024 | US |Design and verification productivity platform |
 |[Riverlane](https://riverlane.com) | QUANTUM | 2016 | UK |Quantum error correction |
 |[Rivos](https://rivosinc.com) | RISC-V | 2021 | US |Stealth |
@@ -367,21 +368,21 @@ BibTeX:
 |[Ubilite](https://ubilite.com) | RF | 2014 | US |Low power wireless communication for IoT |
 |[Ubitium](https://ubitium.com) | AI | 2024 | DE |Universal processor |
 |[Uhnder](https://uhnder.com) | SENSORS | 2015 | US |Digital automotive radar SoC |
+|[Unconventional AI](https://unconv.ai) | AI | 2025 | US |Analog AI chips |
 |[Unifabrix](https://unifabrix.com) | NETWORKING | 2020 | IL |CXL based secure connectivity solution |
 |[Upmem](https://upmem.com) | AI | 2015 | FR |In memory processing devices for big data and AI |
 |[Usound](https://usound.com) | MEMS | 2012 | AU |Sound solutions based on MEMS technology |
 |[Vaire Computing](https://vaire.co) | ANALOG | 2021 | UK |Near zero energy computing |
 |[Vayyar](https://vayyar.com) | SENSORS | 2011 | IL |High resolution image sensors |
 |[Vector Photonics](https://vectorphotonics.co.uk) | PHOTONICS | 2020 | UK |Semiconductor lasers |
-|[Ventana Micro](https://ventanamicro.com) | RISC-V | 2018 | US |RISC-V CPU cores and compute subsystems |
 |[VerifAI](https://verifai.ai) | EDA | 2020 | US |AI assisted hardware design and verification |
 |[Verifaix](https://verifaix.com) | EDA | 2024 | US |AI assisted hardware design and verification |
+|[Vinci](https://getvinci.ai) | EDA | 2023 | US |Physics-based AI for hardware design and simulation |
 |[Viqthor](https://viqthor.com) | QUANTUM | 2023 | FR |Quantum processing |
 |[Visblsemi](https://visiblsemi.com) | EDA | 2024 | US |AI assisted hardware design and verification |
 |[Volantis Semiconductor](https://volantissemi.ai) | AI | 2022 | US |AI processors |
 |[VoltAI](https://voltai.com) | EDA | 2022 | US |AI models for semiconductor |
 |[Vsora](https://vsora.com) | AI | 2015 | FR |AI inference chips |
-|[VyperCore](https://vypercore.com) | RISC-V | 2022 | UK |RISC-V processors |
 |[Wave Photonics](https://wavephotonics.com) | PHOTONICS | 2021 | UK |Photonics design platform |
 |[Welinq](https://welinq.fr) | QUANTUM | 2022 | FR |Quantum interconnects |
 |[Xanadu](https://xanadu.ai) | PHOTONICS | 2016 | US |Photonic based quantum computer |
@@ -392,9 +393,9 @@ BibTeX:
 |[Xsight Labs](https://xsightlabs.com) | HPC | 2017 | IL |Chip sets for accelerating data-intensive workloads |
 |[Yorchip](https://yorchip.com) | CHIPLETS | 2023 | US |Chiplet technology |
 |[Zendar](https://zendar.io) | SENSORS | 2017 | US |High resolution software defined radar |
+|[Zero Point Motion](https://zeropointmotion.com) | MEMS | 2020 | UK |Photonics/MEMS motion sensors |
 |[ZeroASIC](https://zeroasic.com) | CHIPLETS | 2008 | US |Chiplet based ASIC platform |
 |[ZeroPoint](https://zeropoint-tech.com) | MEMORY | 2015 | US |Memory compression technology |
-|[Zero Point Motion](https://zeropointmotion.com) | MEMS | 2020 | UK |Photonics/MEMS motion sensors |
 |[zeroRISC](https://zerorisc.com) | SECURITY | 2023 | US |Open source Root-of-Trust platform |
 
 ## Alumni
@@ -440,8 +441,8 @@ BibTeX:
 |Fungible | Microsoft | 2023 | 190 | [Source](https://blogs.microsoft.com/blog/2023/01/09/microsoft-announces-acquisition-of-fungible-to-accelerate-datacenter-innovation/) |
 |GaN Systems | Infineon | 2023 | 830 | [Source](https://www.infineon.com/cms/en/about-infineon/press/press-releases/2023/INFXX202303-073.html) |
 |Genapsys | Shutdown | 2022 | 0 | [Source](https://cases.ra.kroll.com/genapsys/Home-Index) |
-|Graphcore | Softbank | 2024 | 400 | [Source](https://www.anandtech.com/show/21468/troubled-ai-processor-developer-graphcore-finds-a-buyer-softbank) |
 |GrAI Matter Labs | Snap | 2023 | NA | [Source](https://www.eetimes.com/has-grai-matter-labs-been-snapped-up-by-snap-inc/) |
+|Graphcore | Softbank | 2024 | 400 | [Source](https://www.anandtech.com/show/21468/troubled-ai-processor-developer-graphcore-finds-a-buyer-softbank) |
 |GreenWaves Technologies | Shutdown | 2025 | 0 | [Source](https://www.linkedin.com/feed/update/urn:li:activity:7313159925101166594/) |
 |Groq | Nvidia | 2026 | 20000 | [Source](https://www.nextplatform.com/ai/2026/03/17/nvidia-finally-admits-why-it-shelled-out-20-billion-for-groq/5209495) |
 |Gyrfalcon | Shutdown | 2024 | NA | [Source](https://www.gyrfalcontech.ai) |
@@ -455,11 +456,13 @@ BibTeX:
 |Innoviz | SPAC | 2021 | 371 | [Source](https://www.prnewswire.com/news-releases/innoviz-technologies-and-collective-growth-corporation-announce-closing-of-business-combination-301262031.html) |
 |Insightness | Sony | 2019 | NA | [Source](https://ethz.ch/en/industry/entrepreneurship/explore-startup-portraits-and-success-stories/exits/insightness.html) |
 |Kalray | IPO | 2018 | 100 | [Source](https://www.euronext.com/en/about/media/euronext-press-releases/kalray-sintroduit-sur-euronext-growth) |
-|Kinara | NXP | 2025 | 307 | [Source](https://www.nxp.com/company/about-nxp/newsroom/NW-AI-PR-2025) |
-|Lucata | Shutdown | 2024 | NA | [Source](https://www.linkedin.com/posts/marty-deneroff-2a554_sadly-lucata-emu-technology-ceased-operations-activity-7168985090331500544-xy_D) |
-|Lion Semiconductor | Cirrus | 2021 | 335 | [Source](https://www.ednasia.com/cirrus-logic-to-acquire-lion-semiconductor/) |
-|Lyric | Analog Devices | 2011 | NA | [Source](https://www.eetimes.com/adi-buys-lyric-probability-processing-specialist/) |
 |Kameleon | Ramon Space | 2022 | NA | [Source](https://www.startuphub.ai/ai-exit-events/ramon-space-merges-with-kameleon/) |
+|Kinara | NXP | 2025 | 307 | [Source](https://www.nxp.com/company/about-nxp/newsroom/NW-AI-PR-2025) |
+|Lightelligence | IPO | 2026 | 306 | [Source](https://www.scmp.com/tech/tech-trends/article/3351551/lightelligence-jumps-hong-kong-debut-amid-ai-driven-demand-photonics-chips) |
+|Lighton | IPO | 2024 | 65 | [Source](https://www.reuters.com/technology/artificial-intelligence/frances-lighton-says-valued-65-mln-euronext-ipo-2024-11-21/) |
+|Lion Semiconductor | Cirrus | 2021 | 335 | [Source](https://www.ednasia.com/cirrus-logic-to-acquire-lion-semiconductor/) |
+|Lucata | Shutdown | 2024 | NA | [Source](https://www.linkedin.com/posts/marty-deneroff-2a554_sadly-lucata-emu-technology-ceased-operations-activity-7168985090331500544-xy_D) |
+|Lyric | Analog Devices | 2011 | NA | [Source](https://www.eetimes.com/adi-buys-lyric-probability-processing-specialist/) |
 |Mathstar | Shutdown | 2008 | 0 | [Source](https://www.oregonlive.com/business/2008/05/mathstar_calls_it_quits.html) |
 |Maxeda | Synopsys | 2023 | NA | [Source](https://www.linkedin.com/company/maxeda-technology/?trk=ppro_cprof) |
 |Minima | Bosch | NA | NA | [Source](https://www.acuity.co.uk/successes/acuity-advises-minima-on-its-sale-to-bosch/) |
@@ -468,12 +471,13 @@ BibTeX:
 |Movidius | Intel | 2016 | 400 | [Source](https://siliconangle.com/2016/09/06/intel-buys-movidius-to-boost-machine-vision/) |
 |Nervana | Intel | 2016 | 350 | [Source](https://venturebeat.com/2016/08/09/intel-acquires-deep-learning-startup-nervana) |
 |Neuroblade | Amazon | 2025 | NA | [Source](https://www.storagenewsletter.com/2025/10/23/aws-swallows-neuroblade/) |
-|Nubis | Ciena | 270 | 2025 | [Source](https://www.ciena.com/about/newsroom/press-releases/ciena-to-acquire-nubis-communications-to-expand-its-inside-the-data-center-strategy-and-further-address-growing-ai-workloads) |
+|Nubis | Ciena | 2025 | 270 | [Source](https://www.ciena.com/about/newsroom/press-releases/ciena-to-acquire-nubis-communications-to-expand-its-inside-the-data-center-strategy-and-further-address-growing-ai-workloads) |
 |Nuvia | Qualcomm | 2021 | 1400 | [Source](https://www.fiercewireless.com/devices/qualcomm-to-acquire-nuvia-for-1-4b) |
 |Occuli | Ambarella | 2021 | 307 | [Source](https://www.ambarella.com/news/ambarella-closes-acquisition-of-oculii/) |
 |PA Semi | Apple | 2009 | 278 | [Source](https://www.cnet.com/tech/tech-industry/apple-acquires-low-power-chip-designer-pa-semi) |
 |Pensando | AMD | 2022 | 1900 | [Source](https://www.amd.com/en/press-releases/2022-05-26-amd-expands-data-center-solutions-capabilities-acquisition-pensando) |
 |Perceive | Amazon | 2024 | 80 | [Source](https://www.geekwire.com/2024/amazon-to-acquire-perceive-for-80m-from-xperi-expanding-its-ai-technology-for-edge-devices/) |
+|Pharrowtech | Shutdown | 2025 | 0 | [Source](https://bits-chips.com/article/its-the-end-of-the-line-for-pharrowtech/) |
 |PrimeSense | Apple | 2013 | 350 | [Source](https://techcrunch.com/2013/11/24/apple-primesense-acquisition-confirmed) |
 |Provigent | Broadcom | 2011 | 360 | [Source](https://en.globes.co.il/en/article-1000631723) |
 |Quantenna | Onsemi | 2019 | 1000 | [Source](https://www.bizjournals.com/phoenix/news/2022/09/20/onsemi-close-down-quantenna.html) |
@@ -487,11 +491,12 @@ BibTeX:
 |Stream Processors | Shutdown | 2009 | 0 | [Source](https://venturebeat.com/2009/11/07/chip-design-firm-stream-processors-shutting-down-and-selling-assets/) |
 |Stretch | Exar | 2014 | NA | [Source](https://www.prnewswire.com/news-releases/exar-acquires-stretch-incorporated-240074341.html) |
 |Tabula | Shutdown | 2015 | 0 | [Source](https://semiwiki.com/fpga/4232-tabula-closes-its-doors/) |
-|Tensil.ai | NA | 2022 | NA | NA |
+|Tensil.ai | NA | 2022 | NA | [Source](https://reforgers.com/startups/tensil) |
 |Teramount | Molex | 2026 | 430 | [Source](https://www.calcalistech.com/ctechnews/article/b1intlan11l#google_vignette) |
 |Tilera | Ezchip | 2014 | 50 | [Source](https://www.prnewswire.com/news-releases/ezchip-completes-acquisition-of-tilera-a-leader-in-high-performance-multi-core-processors-281754771.html) |
 |Untether | AMD | 2025 | NA | [Source](https://www.eetimes.com/untether-ai-shuts-down-engineering-team-joins-amd/) |
 |Upverter | Altium | 2017 | 2.8 | [Source](https://pitchbook.com/profiles/company/56161-81#overview) |
 |Ventana | Qualcomm | 2025 | NA | [Source](https://www.crn.com/news/components-peripherals/2025/qualcomm-acquires-risc-v-chip-designer-ventana-to-boost-cpu-capabilities) |
+|VyperCore | Shutdown | 2025 | 0 | [Source](https://find-and-update.company-information.service.gov.uk/company/14244622) |
 |Wavious | Apple | 2022 | NA | [Source](https://pitchbook.com/profiles/company/169888-60#overview) |
 |zGlue | Sold | 2021 | NA | [Source](https://www.reuters.com/technology/chip-wars-how-chiplets-are-emerging-core-part-chinas-tech-strategy-2023-07-13) |

--- a/alumni.csv
+++ b/alumni.csv
@@ -74,6 +74,7 @@ Occuli,Ambarella,2021,307,https://www.ambarella.com/news/ambarella-closes-acquis
 PA Semi,Apple,2009,278,https://www.cnet.com/tech/tech-industry/apple-acquires-low-power-chip-designer-pa-semi
 Pensando,AMD,2022,1900,https://www.amd.com/en/press-releases/2022-05-26-amd-expands-data-center-solutions-capabilities-acquisition-pensando
 Perceive,Amazon,2024,80,https://www.geekwire.com/2024/amazon-to-acquire-perceive-for-80m-from-xperi-expanding-its-ai-technology-for-edge-devices/
+Pharrowtech,Shutdown,2025,0,https://bits-chips.com/article/its-the-end-of-the-line-for-pharrowtech/
 PrimeSense,Apple,2013,350,https://techcrunch.com/2013/11/24/apple-primesense-acquisition-confirmed
 Provigent,Broadcom,2011,360,https://en.globes.co.il/en/article-1000631723
 Quantenna,Onsemi,2019,1000,https://www.bizjournals.com/phoenix/news/2022/09/20/onsemi-close-down-quantenna.html
@@ -87,11 +88,12 @@ Soft Machines,Intel,2016,250,https://www.theregister.com/2016/09/09/intel_soft_m
 Stream Processors,Shutdown,2009,0,https://venturebeat.com/2009/11/07/chip-design-firm-stream-processors-shutting-down-and-selling-assets/
 Stretch,Exar,2014,NA,https://www.prnewswire.com/news-releases/exar-acquires-stretch-incorporated-240074341.html
 Tabula,Shutdown,2015,0,https://semiwiki.com/fpga/4232-tabula-closes-its-doors/
-Tensil.ai,NA,2022,NA,
+Tensil.ai,NA,2022,NA,https://reforgers.com/startups/tensil
 Teramount,Molex,2026,430,https://www.calcalistech.com/ctechnews/article/b1intlan11l#google_vignette
 Tilera,Ezchip,2014,50,https://www.prnewswire.com/news-releases/ezchip-completes-acquisition-of-tilera-a-leader-in-high-performance-multi-core-processors-281754771.html
 Untether,AMD,2025,NA,https://www.eetimes.com/untether-ai-shuts-down-engineering-team-joins-amd/
 Upverter,Altium,2017,2.8,https://pitchbook.com/profiles/company/56161-81#overview
 Ventana,Qualcomm,2025,NA,https://www.crn.com/news/components-peripherals/2025/qualcomm-acquires-risc-v-chip-designer-ventana-to-boost-cpu-capabilities
+VyperCore,Shutdown,2025,0,https://find-and-update.company-information.service.gov.uk/company/14244622
 Wavious,Apple,2022,NA,https://pitchbook.com/profiles/company/169888-60#overview
 zGlue,Sold,2021,NA,https://www.reuters.com/technology/chip-wars-how-chiplets-are-emerging-core-part-chinas-tech-strategy-2023-07-13

--- a/alumni.csv
+++ b/alumni.csv
@@ -38,8 +38,8 @@ Flex Logix,Analog Devices,2024,NA,https://www.linkedin.com/posts/gregory-bryant-
 Fungible,Microsoft,2023,190,https://blogs.microsoft.com/blog/2023/01/09/microsoft-announces-acquisition-of-fungible-to-accelerate-datacenter-innovation/
 GaN Systems,Infineon,2023,830,https://www.infineon.com/cms/en/about-infineon/press/press-releases/2023/INFXX202303-073.html
 Genapsys,Shutdown,2022,0,https://cases.ra.kroll.com/genapsys/Home-Index
-Graphcore,Softbank,2024,400,https://www.anandtech.com/show/21468/troubled-ai-processor-developer-graphcore-finds-a-buyer-softbank
 GrAI Matter Labs,Snap,2023,NA,https://www.eetimes.com/has-grai-matter-labs-been-snapped-up-by-snap-inc/
+Graphcore,Softbank,2024,400,https://www.anandtech.com/show/21468/troubled-ai-processor-developer-graphcore-finds-a-buyer-softbank
 GreenWaves Technologies,Shutdown,2025,0,https://www.linkedin.com/feed/update/urn:li:activity:7313159925101166594/
 Groq,Nvidia,2026,20000,https://www.nextplatform.com/ai/2026/03/17/nvidia-finally-admits-why-it-shelled-out-20-billion-for-groq/5209495
 Gyrfalcon,Shutdown,2024,NA,https://www.gyrfalcontech.ai
@@ -53,11 +53,13 @@ Innovium,Marvell,2021,1100,https://techcrunch.com/2021/08/03/marvell-nabs-innovi
 Innoviz,SPAC,2021,371,https://www.prnewswire.com/news-releases/innoviz-technologies-and-collective-growth-corporation-announce-closing-of-business-combination-301262031.html
 Insightness,Sony,2019,NA,https://ethz.ch/en/industry/entrepreneurship/explore-startup-portraits-and-success-stories/exits/insightness.html
 Kalray,IPO,2018,100,https://www.euronext.com/en/about/media/euronext-press-releases/kalray-sintroduit-sur-euronext-growth
-Kinara,NXP,2025,307,https://www.nxp.com/company/about-nxp/newsroom/NW-AI-PR-2025
-Lucata,Shutdown,2024,NA,https://www.linkedin.com/posts/marty-deneroff-2a554_sadly-lucata-emu-technology-ceased-operations-activity-7168985090331500544-xy_D
-Lion Semiconductor,Cirrus,2021,335,https://www.ednasia.com/cirrus-logic-to-acquire-lion-semiconductor/
-Lyric,Analog Devices,2011,NA,https://www.eetimes.com/adi-buys-lyric-probability-processing-specialist/
 Kameleon,Ramon Space,2022,NA,https://www.startuphub.ai/ai-exit-events/ramon-space-merges-with-kameleon/
+Kinara,NXP,2025,307,https://www.nxp.com/company/about-nxp/newsroom/NW-AI-PR-2025
+Lightelligence,IPO,2026,306,https://www.scmp.com/tech/tech-trends/article/3351551/lightelligence-jumps-hong-kong-debut-amid-ai-driven-demand-photonics-chips
+Lighton,IPO,2024,65,https://www.reuters.com/technology/artificial-intelligence/frances-lighton-says-valued-65-mln-euronext-ipo-2024-11-21/
+Lion Semiconductor,Cirrus,2021,335,https://www.ednasia.com/cirrus-logic-to-acquire-lion-semiconductor/
+Lucata,Shutdown,2024,NA,https://www.linkedin.com/posts/marty-deneroff-2a554_sadly-lucata-emu-technology-ceased-operations-activity-7168985090331500544-xy_D
+Lyric,Analog Devices,2011,NA,https://www.eetimes.com/adi-buys-lyric-probability-processing-specialist/
 Mathstar,Shutdown,2008,0,https://www.oregonlive.com/business/2008/05/mathstar_calls_it_quits.html
 Maxeda,Synopsys,2023,NA,https://www.linkedin.com/company/maxeda-technology/?trk=ppro_cprof
 Minima,Bosch,NA,NA,https://www.acuity.co.uk/successes/acuity-advises-minima-on-its-sale-to-bosch/

--- a/alumni.csv
+++ b/alumni.csv
@@ -68,7 +68,7 @@ Mobix Labs,SPAC,2023,NA,https://mobixlabs.com
 Movidius,Intel,2016,400,https://siliconangle.com/2016/09/06/intel-buys-movidius-to-boost-machine-vision/
 Nervana,Intel,2016,350,https://venturebeat.com/2016/08/09/intel-acquires-deep-learning-startup-nervana
 Neuroblade,Amazon,2025,NA,https://www.storagenewsletter.com/2025/10/23/aws-swallows-neuroblade/
-Nubis,Ciena,270,2025,https://www.ciena.com/about/newsroom/press-releases/ciena-to-acquire-nubis-communications-to-expand-its-inside-the-data-center-strategy-and-further-address-growing-ai-workloads
+Nubis,Ciena,2025,270,https://www.ciena.com/about/newsroom/press-releases/ciena-to-acquire-nubis-communications-to-expand-its-inside-the-data-center-strategy-and-further-address-growing-ai-workloads
 Nuvia,Qualcomm,2021,1400,https://www.fiercewireless.com/devices/qualcomm-to-acquire-nuvia-for-1-4b
 Occuli,Ambarella,2021,307,https://www.ambarella.com/news/ambarella-closes-acquisition-of-oculii/
 PA Semi,Apple,2009,278,https://www.cnet.com/tech/tech-industry/apple-acquires-low-power-chip-designer-pa-semi

--- a/check_and_validate.py
+++ b/check_and_validate.py
@@ -1,0 +1,233 @@
+#!/bin/env python3
+
+import csv
+import re
+import sys
+import ssl
+import time
+import concurrent.futures
+from urllib.request import Request, urlopen
+from urllib.error import HTTPError
+
+TIMEOUT = 15
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/125.0.0.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.5",
+}
+
+def _fetch(url, use_ssl=True):
+    ctx = None
+    if use_ssl:
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+    for method in ("HEAD", "GET"):
+        req = Request(url, method=method, headers=HEADERS)
+        try:
+            urlopen(req, timeout=TIMEOUT, context=ctx)
+            return True
+        except HTTPError as e:
+            if e.code < 500:
+                return True
+        except Exception:
+            pass
+    return False
+
+def check_url(domain):
+    candidates = [f"https://{domain}"]
+    if not domain.startswith("www."):
+        candidates.append(f"https://www.{domain}")
+    for url in candidates:
+        if _fetch(url, use_ssl=True):
+            return True
+    for prefix in ("", "www."):
+        url = f"http://{prefix}{domain}"
+        if _fetch(url, use_ssl=False):
+            return True
+    return False
+
+def check_year(v):
+    return re.fullmatch(r"\d{4}", v) is not None
+
+def load_technologies():
+    techs = {}
+    with open("technologies.csv", newline="", encoding="utf-8") as f:
+        for r in csv.DictReader(f):
+            techs[r["Technology"]] = r["Description"]
+    return techs
+
+def validate_startups(valid_tech):
+    issues = []
+    rows = []
+    seen_company = set()
+    seen_website = set()
+    with open("startups.csv", newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        if reader.fieldnames != ["Company","Website","Technology","Country","Founded","Description"]:
+            issues.append(("ERROR", "startups.csv", 1, f"Bad headers: {reader.fieldnames}"))
+        for row in reader:
+            n = reader.line_num
+            c = row["Company"].strip()
+            w = row["Website"].strip()
+            t = row["Technology"].strip()
+            co = row["Country"].strip()
+            y = row["Founded"].strip()
+            d = row["Description"].strip()
+            if not c:
+                issues.append(("ERROR", "startups.csv", n, "Empty Company"))
+                continue
+            if not w:
+                issues.append(("ERROR", "startups.csv", n, f"Empty Website (Company: {c})"))
+                continue
+            if c in seen_company:
+                issues.append(("ERROR", "startups.csv", n, f"Duplicate Company: {c}"))
+                continue
+            if w.lower() in seen_website:
+                issues.append(("ERROR", "startups.csv", n, f"Duplicate Website: {w}"))
+                continue
+            seen_company.add(c)
+            seen_website.add(w.lower())
+            if t not in valid_tech:
+                issues.append(("ERROR", "startups.csv", n, f"Unknown Technology: {t} (Company: {c})"))
+            if not check_year(y):
+                issues.append(("ERROR", "startups.csv", n, f"Invalid Founded year: {y} (Company: {c})"))
+            if re.fullmatch(r"[A-Z]{2}", co) is None:
+                issues.append(("WARNING", "startups.csv", n, f"Non-standard Country: {co} (Company: {c})"))
+            if not d:
+                issues.append(("WARNING", "startups.csv", n, f"Empty Description (Company: {c})"))
+            rows.append({**row, "_domain": w, "_company": c, "_founded": y, "_desc": d})
+    return rows, issues
+
+COUNTRY_RE = re.compile(r"[A-Z]{2}")
+EXIT_RE = re.compile(r"[A-Z][a-zA-Z.&]+")
+
+def validate_alumni():
+    issues = []
+    seen_company = set()
+    seen_link = set()
+    known_exits = {"IPO","SPAC","Shutdown","Sold"}
+    with open("alumni.csv", newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        if reader.fieldnames != ["Company","Exit","Year","Value($M)","Link"]:
+            issues.append(("ERROR", "alumni.csv", 1, f"Bad headers: {reader.fieldnames}"))
+        for row in reader:
+            n = reader.line_num
+            c = row["Company"].strip()
+            e = row["Exit"].strip()
+            y = row["Year"].strip()
+            v = row["Value($M)"].strip()
+            l = row["Link"].strip()
+            if not c:
+                issues.append(("ERROR", "alumni.csv", n, "Empty Company"))
+                continue
+            if c in seen_company:
+                issues.append(("ERROR", "alumni.csv", n, f"Duplicate Company: {c}"))
+                continue
+            seen_company.add(c)
+            if not e:
+                issues.append(("ERROR", "alumni.csv", n, f"Empty Exit (Company: {c})"))
+            elif e not in known_exits and not EXIT_RE.fullmatch(e):
+                issues.append(("WARNING", "alumni.csv", n, f"Unusual Exit type: {e} (Company: {c})"))
+            if y != "NA":
+                if not check_year(y):
+                    issues.append(("ERROR", "alumni.csv", n, f"Invalid Year: {y} (Company: {c})"))
+                elif not (2000 <= int(y) <= 2026):
+                    issues.append(("WARNING", "alumni.csv", n, f"Year out of range: {y} (Company: {c})"))
+            if v != "NA" and not re.fullmatch(r"\d+(\.\d+)?", v):
+                issues.append(("ERROR", "alumni.csv", n, f"Invalid Value: {v} (Company: {c})"))
+            if l != "NA":
+                if not re.fullmatch(r"https?://.+", l):
+                    issues.append(("ERROR", "alumni.csv", n, f"Invalid Link: {l} (Company: {c})"))
+                elif l in seen_link:
+                    issues.append(("WARNING", "alumni.csv", n, f"Duplicate Link (Company: {c})"))
+                seen_link.add(l)
+    return issues
+
+def check_urls_parallel(rows, workers):
+    url_results = []
+    passed = failed = 0
+    total = len(rows)
+    done = 0
+    start = time.time()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+        fut_to_row = {pool.submit(check_url, r["_domain"]): r for r in rows}
+        for fut in concurrent.futures.as_completed(fut_to_row):
+            row = fut_to_row[fut]
+            alive = fut.result()
+            done += 1
+            elapsed = time.time() - start
+            pct = done / total * 100
+            eta = elapsed / done * (total - done) if done else 0
+            bar = "#" * int(pct / 5) + "-" * (20 - int(pct / 5))
+            sys.stderr.write(f"\r  [{bar}] {pct:5.1f}%  {done}/{total}  {elapsed:.0f}s elapsed  ETA {eta:.0f}s")
+            sys.stderr.flush()
+            if alive:
+                passed += 1
+            else:
+                failed += 1
+                url_results.append(f"  FAIL  {row['_domain']}  |  {row['_company']}  |  {row['_founded']}  |  {row['_desc']}")
+    sys.stderr.write(f"\r{' ' * 80}\r")
+    return passed, failed, url_results
+
+def main():
+    workers = int(sys.argv[1]) if len(sys.argv) > 1 else 8
+
+    print("=" * 60)
+    print(" 1. Loading technologies ...")
+    print("=" * 60)
+    valid_tech = load_technologies()
+    print(f"    {len(valid_tech)} technologies loaded\n")
+
+    print("=" * 60)
+    print(" 2. Validating startups.csv ...")
+    print("=" * 60)
+    rows, issues = validate_startups(valid_tech)
+    print(f"    {len(rows)} valid rows\n")
+
+    print("=" * 60)
+    print(" 3. Validating alumni.csv ...")
+    print("=" * 60)
+    issues += validate_alumni()
+    print()
+
+    print("=" * 60)
+    print(f" 4. Checking URLs (workers={workers}) ...")
+    print("=" * 60)
+    passed, failed, url_results = check_urls_parallel(rows, workers)
+
+    errs = [i for i in issues if i[0] == "ERROR"]
+    warns = [i for i in issues if i[0] == "WARNING"]
+
+    print(f"\n{'=' * 60}")
+    print(" RESULTS")
+    print(f"{'=' * 60}")
+
+    if url_results:
+        print(f"\n  Failed URLs ({failed}):")
+        for r in url_results:
+            print(r)
+
+    if errs:
+        print(f"\n  Validation Errors ({len(errs)}):")
+        for _, f, n, m in errs:
+            print(f"  ERROR   {f}:{n}  {m}")
+    if warns:
+        print(f"\n  Warnings ({len(warns)}):")
+        for _, f, n, m in warns:
+            print(f"  WARNING {f}:{n}  {m}")
+
+    total = passed + failed
+    print(f"\n  URLs:    {passed} passed, {failed} failed ({passed/total*100:.1f}% success)")
+    print(f"  Errors:   {len(errs)}")
+    print(f"  Warnings: {len(warns)}")
+
+    if failed or errs:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/startups.csv
+++ b/startups.csv
@@ -34,9 +34,9 @@ Aule Technologies,auletechnologies.com,EDA,US,2022,AI/physics based design platf
 Avicena,avicena.tech,PHOTONICS,US,2019,Optical uLed interconnect technology
 Axelera,axelera.ai,AI,NL,2021,Low power AI edge processors
 Ayar Labs,ayarlabs.com,PHOTONICS,US,2015,Electronic-photonic communication chip sets
-Azimuth AI,Azimuth-ai.com,ASIC,US,2023,Edge AI ASICs
+Azimuth AI,azimuth-ai.com,ASIC,US,2023,Edge AI ASICs
 Baya Systems,bayasystems.com,CHIPLETS,US,2023,Chiplet Based Semiconductor Design
-Beacon Photonics,beaconphotonics,PHOTONICS,US,2023,Integrated photonics platform
+Beacon Photonics,beaconphotonics.com,PHOTONICS,US,2023,Integrated photonics platform
 Beam,beamshaping.io,RF,IL,2015,Phased array antennas
 Belfort,belfortlabs.com,SECURITY,BE,2025,Hardware for encrypted compute (FHE)
 Black Semiconductor,blacksemiconductor.de,MFG,DE,2021,Graphene electronics/photonics translators
@@ -171,7 +171,7 @@ Mythic,mythic-ai.com,AI,US,2012,Analog ML accelerators
 MZ Technologies,genioevo.com,EDA,IT,2014,EDA solutions for advanced packaging
 Nanopower,nanopowersemi.com,ANALOG,NO,2017,Smart power management ICs
 NcodiN,ncodin.com,PHOTONICS,FR,2023,Optical interposers
-Neologic,neologic.com,MFG,IL,2021,Quasi-CMOS transistor technology
+Neologic,neologicvlsi.com,MFG,IL,2021,Quasi-CMOS transistor technology
 Netrasemi,netrasemi.com,AI,IN,2020,AI Hardware chips
 Neureality,neureality.ai,AI,IL,2019,Purpose-built AI-centric architecture
 NeuroBlade,neuroblade.com,AI,IL,2018,Accelerators for high throughput data analytics
@@ -198,7 +198,6 @@ Panmnesia,panmnesia.com,MEMORY,KR,2022,CXL IP
 par.tcl,partcl.com,EDA,US,2024,Physics based eda tools
 persimmons,persimmons.ai,AI,US,2023,"Flexible, low-power generative AI inference system "
 Phanofi,phanofi.com,PHOTONICS,DK,2022,Optical transceivers for data centers & HPC
-Pharrowtech,pharrowtech.com,RF,BE,2018,RF ICs for high speed wireless links
 Phoenix Semiconductor,phoenixsemicorp.com,ASIC,US,2023,Drop in replacements for discontinued devices
 Picocom,picocom.com,RF,UK,2019,Semiconductor products for 5G infrastructure
 Piris Labs,pirislabs.io,AI,US,2025,Optical inference engine
@@ -220,7 +219,7 @@ Qromis,qromis.com,MFG,US,2015,Semiconductor materials for WBG
 Qruise,qruise.com,QUANTUM,DE,2021,Design and verification of quantum systems
 Quadric.io,quadric.io,AI,US,2016,Edge processing for edge devices
 Qualinx,qualinx.io,RF,NL,2015,IoT GNSS based tracking and connectivity
-Quantum Motion,quantummmotion.tech,QUANTUM,UK,2017,Scalable quantum computer architectural technology
+Quantum Motion,quantummotion.com,QUANTUM,UK,2017,Scalable quantum computer architectural technology
 Quera Computing,quera.com,QUANTUM,US,2018,Neutral atom based quantum computers
 Quilter,quilter.ai,EDA,US,2020,AI driven PCB design
 Quintessent,quintessent.com,PHOTONICS,US,2019,Optical interconnect
@@ -296,7 +295,6 @@ Usound,usound.com,MEMS,AU,2012,Sound solutions based on MEMS technology
 Vaire Computing,vaire.co,ANALOG,UK,2021,Near zero energy computing
 Vayyar,vayyar.com,SENSORS,IL,2011,High resolution image sensors
 Vector Photonics,vectorphotonics.co.uk,PHOTONICS,UK,2020,Semiconductor lasers
-Ventana Micro,ventanamicro.com,RISC-V,US,2018,RISC-V CPU cores and compute subsystems
 VerifAI,verifai.ai,EDA,US,2020,AI assisted hardware design and verification
 Verifaix,verifaix.com,EDA,US,2024,AI assisted hardware design and verification
 Vinci,getvinci.ai,EDA,US,2023,Physics-based AI for hardware design and simulation
@@ -305,7 +303,6 @@ Visblsemi,visiblsemi.com,EDA,US,2024,AI assisted hardware design and verificatio
 Volantis Semiconductor,volantissemi.ai,AI,US,2022,AI processors
 VoltAI,voltai.com,EDA,US,2022,AI models for semiconductor
 Vsora,vsora.com,AI,FR,2015,AI inference chips
-VyperCore,vypercore.com,RISC-V,UK,2022,RISC-V processors
 Wave Photonics,wavephotonics.com,PHOTONICS,UK,2021,Photonics design platform
 Welinq,welinq.fr,QUANTUM,FR,2022,Quantum interconnects
 Xanadu,xanadu.ai,PHOTONICS,US,2016,Photonic based quantum computer

--- a/startups.csv
+++ b/startups.csv
@@ -65,7 +65,7 @@ Chipletz,chipletz.com,CHIPLETS,US,2021,Smart substrate for chiplet integration
 Chipmind,chipmind.ai,EDA,CH,2024,Agentic chip design
 Chipstack,chipstack.com,EDA,US,2023,AI based chip design methodology
 Circuit Mind,circuitmind.io,EDA,UK,2018,PCB design tools
-CircuitLeap.ai,circuitleap.ai,EDA,Portugal,2024,Automated analog design with GPU and AI
+CircuitLeap.ai,circuitleap.ai,EDA,PT,2024,Automated analog design with GPU and AI
 Classiq,classiq.io,EDA,IL,2020,Quantum computing software
 Codasip,codasip.com,RISC-V,DE,2014,Supplier of RISC-V IP cores
 Cognichip,cognichip.ai,EDA,US,2024,AI platform for chip design

--- a/startups.csv
+++ b/startups.csv
@@ -30,16 +30,15 @@ Atlant 3D,atlant3d.com,MFG,DK,2018,Atomic scale 3d material printing
 Atlantic Quantum,atlantic-quantum.com,QUANTUM,US,2022,Scalable quantum computers
 Atmosic,atmosic.com,RF,US,2016,Battery free wireless devices
 Atoms AI,atomsai.net,EDA,US,2024,AI driven verification
+Aule Technologies,auletechnologies.com,EDA,US,2022,AI/physics based design platform
 Avicena,avicena.tech,PHOTONICS,US,2019,Optical uLed interconnect technology
 Axelera,axelera.ai,AI,NL,2021,Low power AI edge processors
-Aule Technologies,auletechnologies.com,EDA,US,2022,AI/physics based design platform
 Ayar Labs,ayarlabs.com,PHOTONICS,US,2015,Electronic-photonic communication chip sets
 Azimuth AI,Azimuth-ai.com,ASIC,US,2023,Edge AI ASICs
 Baya Systems,bayasystems.com,CHIPLETS,US,2023,Chiplet Based Semiconductor Design
 Beacon Photonics,beaconphotonics,PHOTONICS,US,2023,Integrated photonics platform
 Beam,beamshaping.io,RF,IL,2015,Phased array antennas
 Belfort,belfortlabs.com,SECURITY,BE,2025,Hardware for encrypted compute (FHE)
-Build4Sim Inc,build4sim.com,EDA,2025, accelerating Spice simulation
 Black Semiconductor,blacksemiconductor.de,MFG,DE,2021,Graphene electronics/photonics translators
 Blueshift Memory,blueshiftmemory.com,MEMORY,UK,2016,High performance memory centric architecture
 Bluespec,bluespec.com,RISC-V,US,2003,RISC-V IP and System Development Tools
@@ -48,20 +47,22 @@ Bolt Semiconductor,boltsemi.com,MFG,US,2024,Vertical GaN technology
 BoolSi,boolsi.com,EDA,US,2023,"Generate RTL from any code base, in any language"
 bos semiconductors,bos-semi.com,ASIC,KR,2022,Automotive ASICs
 Bronco AI,bronco.ai,EDA,US,2022,AI tools for chip development
-cassia.ai,cassia.ai,AI,US,2021,AI Hardware IP
+Build4Sim Inc,build4sim.com,EDA,US,2025,Accelerating Spice simulation
 cadlab.io,cadlab.io,EDA,US,2015,Collaboration tools for PCB design
 Cadstrom,cadstrom.io,EDA,CA,2023,AI based PCB design
+cassia.ai,cassia.ai,AI,US,2021,AI Hardware IP
 Celera,celeratechnologies.com,EDA,US,2018,Automated analog/mixed-signal IC development tool
+Celero Communications,celero.inc,NETWORKING,US,2024,Coherent DSP platform for high-bandwidth low-power optical connectivity
 Celestial AI,celestial.ai,PHOTONICS,US,2020,Photonic fabric optical interconnect technology
 Cellium,cellium.net,RF,IL,2016,Wireless infrastructure for indoor connectivity
 Celtro,celtro.de,HEALTH,DE,2019,Energy harvesting implantable medical devices
 Celus,celus.io,EDA,DE,2016,PCB design tools
-Cerebras,cerebras.net,HPC,US,2016,Wafer scale processors
 Ceremorphic,ceremorphic.com,HPC,US,2020,Analog computing architecture
 Cerfe Labs,cerfelabs.com,MFG,US,2020,Electronics materials and device research
-Chipmind,chipmind.ai,EDA,CH,2024,Agentic chip design
+ChipAgents,chipagents.ai,EDA,US,2024,Agentic AI chip design environment
 Chipflow,chipflow.io,ASIC,UK,2021,ASIC design platform
 Chipletz,chipletz.com,CHIPLETS,US,2021,Smart substrate for chiplet integration
+Chipmind,chipmind.ai,EDA,CH,2024,Agentic chip design
 Chipstack,chipstack.com,EDA,US,2023,AI based chip design methodology
 Circuit Mind,circuitmind.io,EDA,UK,2018,PCB design tools
 CircuitLeap.ai,circuitleap.ai,EDA,Portugal,2024,Automated analog design with GPU and AI
@@ -77,20 +78,19 @@ DASH Tech IC,dashtechic.com,HPC,US,2021,Flexible processors for embedded applica
 DeepX,deepx.ai,AI,KR,2018,AI processors
 DeGirum,degirum.ai,AI,US,2017,AI platform for edge applications
 Denpaflux,denpaflux.com,EDA,DE,2022,EMC analysis platform for design engineering teams
-Diode Computers,diode.computer,EDA,US,2024,AI based PCB design
 Dfiant,dfiant.works,EDA,US,2022,Chip design tools
+Diode Computers,diode.computer,EDA,US,2024,AI based PCB design
 Dnotitia,dnotitia.com,AI,KR,2023,AI processors
 Dover,dovermicrosystems.com,SECURITY,US,2017,SoC security IP
-Dust Photonics,dustphotonics.com,PHOTONICS,IL,2017,Small footprint integrate photonics transceivers
 DreamBig,dreambigsemi.com,CHIPLETS,US,2019,Chiplet based ASIC platform
+Dust Photonics,dustphotonics.com,PHOTONICS,IL,2017,Small footprint integrate photonics transceivers
 EdgeCortix,edgecortix.com,AI,US,2019,AI accelerators for edge devices
 EdgeQ,edgeq.io,RF,US,2018,Base station-on-a-chip
-Efinix,efinixinc.com,FPGA,US,2012,Programmable FPGA products
 Efficient Computer,efficient.computer,HPC,US,2022,Energy efficient general-purpose processor
+Efinix,efinixinc.com,FPGA,US,2012,Programmable FPGA products
 Eliyan,eliyan.com,CHIPLETS,US,2021,Interconnect technology
 EnCharge AI,enchargeai.com,AI,US,2021,AI processing platform
 Enlightra,enlightra.com,PHOTONICS,US,2017,Optical microresonator technology
-Enosemi,enosemi.com,PHOTONICS,US,2023,Photonics subsystems
 enzzo,enzzo.ai,EDA,US,2024,AI driven hardware development
 Equal1,equal1.com,QUANTUM,IE,2017,Silicon spin qubits for scalable quantum computing
 Eridan,eridan.io,RF,US,2013,RF front end for for wireless telecommunications
@@ -135,25 +135,25 @@ Jeeva Wireless,jeevawireless.com,RF,US,2015,Battery-free wireless sensing techno
 Jitx,jitx.com,EDA,US,2016,PCB design tools
 Kandou,kandou.com,NETWORKING,CH,2011,Chip-to-chip connectivity solutions
 Kepler Computing,keplercompute.com,HPC,US,2018,Stealth
-Kittycad,zoo.dev,EDA,US,2021,AI driven CAD
 Keysom,keysom.io,RISC-V,FR,2022,RISC-V design platform
+Kittycad,zoo.dev,EDA,US,2021,AI driven CAD
 Kneron,kneron.com,AI,US,2015,Edge AI devices
 Krutrim,olakrutrim.com,AI,IN,2023,AI hardware
 Lemurian Labs,lemurianlabs.com,AI,CA,2018,AI computing platform
 Light Solver,lightsolver.com,PHOTONICS,IL,2019,Optical computing platform
 Light Trace Photonics,ltphotonics.co.uk,PHOTONICS,UK,2021,Platform for rapid photonic product development
-Lightelligence,lightelligence.ai,PHOTONICS,US,2017,Optical computing platform
 Lightium,lightium.co,MFG,CH,2023,Photonics foundry
 Lightmatter,lightmatter.co,PHOTONICS,US,2017,Optical computing platform
-Lighton,lighton.ai,PHOTONICS,FR,2015,Optical computing platform
-Literal Labs,Literal-labs.ai,AI,UK,2023,Explainable AI using Tsetlin machines
 Linctrinsic,lintrinsicsemi.com,RF,US,2021,Fast RF switches
 Linque,linque.eu,PHOTONICS,DE,2023,Optical computing 
+Literal Labs,Literal-labs.ai,AI,UK,2023,Explainable AI using Tsetlin machines
 Lubis EDA,Lubis-eda.com,EDA,DE,2021,Cloud based formal verification platform
 Lumai,luma.ai,PHOTONICS,UK,2021,3D optical computing
 Luminous Computing,luminous.com,PHOTONICS,US,2018,Optical computing platform
 Lumotive,lumotive.com,PHOTONICS,US,2017,Optical beam forming sensors
 Lyte AI,lyte.ai,AI,US,2021,Perception layer for physical AI
+Magics Technologies,magics.tech,SPACE,BE,2015,Radiation-hardened ICs for space systems and nuclear infrastructure
+Maieutic Semiconductors,maieuticsemi.com,EDA,IN,2025,Generative AI copilot for analog chip design
 Majestic Labs,majestic-labs.ai,AI,IL,2023,AI procesor
 MangoBoost,mangoboost.io,HPC,US,2022,Data processing units for data center
 Matx,matx.com,AI,US,2022,Platform for AGI
@@ -163,8 +163,9 @@ Mintneuro,mintneuro.com,HEALTH,UK,2015,Neural implants
 Mobilint,mobilint.com,AI,KR,2019,AI inference accelerators
 Morphing Machines,morphing.in,HPC,IN,2006,Reconfigurable processors
 Morse Micro,morsemicro.com,RF,AU,2016,Low-power Wi-Fi chips
-Mosaic SoC,mosaic-soc.com/,ASIC,CH,2024,Specialized chips designed for AR glasses
+Mosaic SoC,mosaic-soc.com,ASIC,CH,2024,Specialized chips designed for AR glasses
 Motivo,motivo.ai,EDA,US,2015,Explainable AI and ML for chip design optimization
+Movandi,movandi.com,RF,US,2016,RF chipsets
 Movellus,movellus.com,ANALOG,US,2014,Clock distribution IP
 Mythic,mythic-ai.com,AI,US,2012,Analog ML accelerators
 MZ Technologies,genioevo.com,EDA,IT,2014,EDA solutions for advanced packaging
@@ -200,6 +201,7 @@ Phanofi,phanofi.com,PHOTONICS,DK,2022,Optical transceivers for data centers & HP
 Pharrowtech,pharrowtech.com,RF,BE,2018,RF ICs for high speed wireless links
 Phoenix Semiconductor,phoenixsemicorp.com,ASIC,US,2023,Drop in replacements for discontinued devices
 Picocom,picocom.com,RF,UK,2019,Semiconductor products for 5G infrastructure
+Piris Labs,pirislabs.io,AI,US,2025,Optical inference engine
 Plaid Semiconductor,plaidsemi.com,CHIPLETS,US,2023,Interposers for chiplet integration
 Pliops,pliops.com,HPC,IL,2017,Scalable data handling/acceleration
 PointCloud,point.cloud,SENSORS,US,2017,4D imaging sensors
@@ -210,7 +212,6 @@ PragmatiC,pragmaticsemi.com,MFG,UK,2010,Manufacturer of low-cost flexible integr
 Precision Innovations,precisioninno.com,EDA,US,2019,Developing and supporting OpenROAD
 Primemas,primemas.com,CHIPLETS,US,2023,Platform for rapid SoC system development
 Primis,primis.ai,EDA,US,2023,Generative-AI driven hardware design
-Piris Labs,pirislabs.io/,AI,US,2025,Optical inference engine
 proteanTecs,proteantecs.com,ANALOG,IL,2017,Analytics platform for advanced chip design
 PseudolithIC,pseudolithic.com,MFG,US,2019,Integration process for RF applications
 PsiQuantum,psiquantum.com,QUANTUM,US,2015,Quantum computers
@@ -235,6 +236,7 @@ Recogni,recogni.com,AI,US,2017,Visual perception platform for autonomous vehicle
 RED Semiconductor,redsemiconductor.com,HPC,UK,2021,Processor technology
 Redwood EDA,redwoodeda.com,EDA,US,2015,Transaction level hardware design platform
 Retym,retym.com,AI,US,2021,Stealth
+Ricursive Intelligence,ricursive.com,EDA,US,2025,AI models to automate all stages of chip design and verification
 RISE,Rise-da.com,EDA,US,2024,Design and verification productivity platform
 Riverlane,riverlane.com,QUANTUM,UK,2016,Quantum error correction
 Rivos,rivosinc.com,RISC-V,US,2021,Stealth
@@ -287,6 +289,7 @@ TriEye,trieye.tech,SENSORS,IL,2017,Short-wave infrared imaging systems
 Ubilite,ubilite.com,RF,US,2014,Low power wireless communication for IoT
 Ubitium,ubitium.com,AI,DE,2024,Universal processor
 Uhnder,uhnder.com,SENSORS,US,2015,Digital automotive radar SoC
+Unconventional AI,unconv.ai,AI,US,2025,Analog AI chips
 Unifabrix,unifabrix.com,NETWORKING,IL,2020,CXL based secure connectivity solution
 Upmem,upmem.com,AI,FR,2015,In memory processing devices for big data and AI
 Usound,usound.com,MEMS,AU,2012,Sound solutions based on MEMS technology
@@ -296,6 +299,7 @@ Vector Photonics,vectorphotonics.co.uk,PHOTONICS,UK,2020,Semiconductor lasers
 Ventana Micro,ventanamicro.com,RISC-V,US,2018,RISC-V CPU cores and compute subsystems
 VerifAI,verifai.ai,EDA,US,2020,AI assisted hardware design and verification
 Verifaix,verifaix.com,EDA,US,2024,AI assisted hardware design and verification
+Vinci,getvinci.ai,EDA,US,2023,Physics-based AI for hardware design and simulation
 Viqthor,viqthor.com,QUANTUM,FR,2023,Quantum processing
 Visblsemi,visiblsemi.com,EDA,US,2024,AI assisted hardware design and verification
 Volantis Semiconductor,volantissemi.ai,AI,US,2022,AI processors
@@ -312,7 +316,7 @@ Xscape Photonics,xscapephotonics.com,PHOTONICS,US,2022,Photonic communication ch
 Xsight Labs,xsightlabs.com,HPC,IL,2017,Chip sets for accelerating data-intensive workloads
 Yorchip,yorchip.com,CHIPLETS,US,2023,Chiplet technology
 Zendar,zendar.io,SENSORS,US,2017,High resolution software defined radar
+Zero Point Motion,zeropointmotion.com,MEMS,UK,2020,Photonics/MEMS motion sensors
 ZeroASIC,zeroasic.com,CHIPLETS,US,2008,Chiplet based ASIC platform
 ZeroPoint,zeropoint-tech.com,MEMORY,US,2015,Memory compression technology
-Zero Point Motion,zeropointmotion.com,MEMS,UK,2020,Photonics/MEMS motion sensors
 zeroRISC,zerorisc.com,SECURITY,US,2023,Open source Root-of-Trust platform


### PR DESCRIPTION
### New additions (8)
- Celero Communications
- ChipAgents
- Magics Technologies
- Maieutic Semiconductors
- Movandi
- Ricursive Intelligence
- Unconventional AI
- Vinci

### Removed from startups.csv (7)
- Cerebras (IPO Nasdaq 2026,  already in  alumni)
- Enosemi (acquired by AMD 2025,  already in  alumni)
- Lightelligence (IPO HKEX 2026, moved to alumni)
- Lighton (IPO Euronext 2024, moved to alumni)
- Pharrowtech (shutdown 2025, moved to alumni)
- Ventana Micro (acquired by Qualcomm 2025, already in  alumni)
- VyperCore (shutdown 2025, moved to alumni)

### Fixes in startups.csv (8)
- Azimuth AI lowercase (Azimuth-ai.com -> azimuth-ai.com)
- Beacon Photonics missing TLD (beaconphotonics -> beaconphotonics.com)
- Neologic wrong domain (neologic.com -> neologicvlsi.com)
- Quantum Motion typo (quantummmotion.tech -> quantummotion.com)
- Build4Sim: added missing country (US)
- Piris Labs: removed trailing slash from URL
- Mosaic SoC: removed trailing slash from URL
- CircuitLeap.ai: Portugal → PT (should be ISO 2-letter code)

### Added to alumni.csv (4)
- Lightelligence (IPO HKEX 2026)
- Lighton (IPO Euronext 2024)
- Pharrowtech (shutdown 2025)
- VyperCore (shutdown 2025)

### Fixes in alumni.csv (2)
- Tensil.ai (add source link)
- Nubis row had Year/Value swapped (270 → 2025, 2025 → 270)

### check-and-validate utility (check_and_validate.py):
- Validates startups.csv and alumni.csv fields,
  checks all startup URLs are reachable (multi-threaded with progress bar),
  prints summary, exits non-zero on failures/errors