### PR TITLE
Fix malformed Build4Sim row and dead Quantum Motion URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ BibTeX:
 |[Beacon Photonics](https://beaconphotonics) | PHOTONICS | 2023 | US |Integrated photonics platform |
 |[Beam](https://beamshaping.io) | RF | 2015 | IL |Phased array antennas |
 |[Belfort](https://belfortlabs.com) | SECURITY | 2025 | BE |Hardware for encrypted compute (FHE) |
-|[Build4Sim Inc](https://build4sim.com) | EDA |  accelerating Spice simulation | 2025 |None |
+|[Build4Sim Inc](https://build4sim.com) | EDA | 2025 | US |Accelerating Spice simulation |
 |[Black Semiconductor](https://blacksemiconductor.de) | MFG | 2021 | DE |Graphene electronics/photonics translators |
 |[Blueshift Memory](https://blueshiftmemory.com) | MEMORY | 2016 | UK |High performance memory centric architecture |
 |[Bluespec](https://bluespec.com) | RISC-V | 2003 | US |RISC-V IP and System Development Tools |
@@ -299,7 +299,7 @@ BibTeX:
 |[Qruise](https://qruise.com) | QUANTUM | 2021 | DE |Design and verification of quantum systems |
 |[Quadric.io](https://quadric.io) | AI | 2016 | US |Edge processing for edge devices |
 |[Qualinx](https://qualinx.io) | RF | 2015 | NL |IoT GNSS based tracking and connectivity |
-|[Quantum Motion](https://quantummmotion.tech) | QUANTUM | 2017 | UK |Scalable quantum computer architectural technology |
+|[Quantum Motion](https://quantummotion.com) | QUANTUM | 2017 | UK |Scalable quantum computer architectural technology |
 |[Quera Computing](https://quera.com) | QUANTUM | 2018 | US |Neutral atom based quantum computers |
 |[Quilter](https://quilter.ai) | EDA | 2020 | US |AI driven PCB design |
 |[Quintessent](https://quintessent.com) | PHOTONICS | 2019 | US |Optical interconnect |

--- a/startups.csv
+++ b/startups.csv
@@ -39,7 +39,7 @@ Baya Systems,bayasystems.com,CHIPLETS,US,2023,Chiplet Based Semiconductor Design
 Beacon Photonics,beaconphotonics,PHOTONICS,US,2023,Integrated photonics platform
 Beam,beamshaping.io,RF,IL,2015,Phased array antennas
 Belfort,belfortlabs.com,SECURITY,BE,2025,Hardware for encrypted compute (FHE)
-Build4Sim Inc,build4sim.com,EDA,2025, accelerating Spice simulation
+Build4Sim Inc,build4sim.com,EDA,US,2025,Accelerating Spice simulation
 Black Semiconductor,blacksemiconductor.de,MFG,DE,2021,Graphene electronics/photonics translators
 Blueshift Memory,blueshiftmemory.com,MEMORY,UK,2016,High performance memory centric architecture
 Bluespec,bluespec.com,RISC-V,US,2003,RISC-V IP and System Development Tools
@@ -219,7 +219,7 @@ Qromis,qromis.com,MFG,US,2015,Semiconductor materials for WBG
 Qruise,qruise.com,QUANTUM,DE,2021,Design and verification of quantum systems
 Quadric.io,quadric.io,AI,US,2016,Edge processing for edge devices
 Qualinx,qualinx.io,RF,NL,2015,IoT GNSS based tracking and connectivity
-Quantum Motion,quantummmotion.tech,QUANTUM,UK,2017,Scalable quantum computer architectural technology
+Quantum Motion,quantummotion.com,QUANTUM,UK,2017,Scalable quantum computer architectural technology
 Quera Computing,quera.com,QUANTUM,US,2018,Neutral atom based quantum computers
 Quilter,quilter.ai,EDA,US,2020,AI driven PCB design
 Quintessent,quintessent.com,PHOTONICS,US,2019,Optical interconnect


### PR DESCRIPTION
Two data errors in `startups.csv`, both visible in the generated README table today.

### 1. `Build4Sim Inc` row is missing a field

```
Build4Sim Inc,build4sim.com,EDA,2025, accelerating Spice simulation
```

This row has 5 fields where the header defines 6 — `Country` was omitted — so every
column after `Technology` shifts left. It's the only row in the file that doesn't have
6 fields. `csv.DictReader` therefore parses it as:

| field | parsed as |
|---|---|
| Country | `2025` |
| Founded | `" accelerating Spice simulation"` |
| Description | `None` |

which `update.py` renders into the README as:

```
|[Build4Sim Inc](https://build4sim.com) | EDA |  accelerating Spice simulation | 2025 |None |
```

Fixed to:

```
Build4Sim Inc,build4sim.com,EDA,US,2025,Accelerating Spice simulation
```

Also capitalised the description — all 316 other entries start with a capital and none
carry a leading space.

**On the `US` value:** the site doesn't state a location outright, so this is inferred
and worth a sanity check. It's incorporated as "Build4Sim Inc.", and both founders are
MIT: CEO Ajay Brahmakshatriya completed his PhD at MIT CSAIL in 2025
(https://intimeand.space/), and co-founder Saman Amarasinghe is a Professor of Computer
Science at MIT (https://people.csail.mit.edu/saman/). Happy to change it if you know
better.

### 2. `Quantum Motion` website is a typo

```
Quantum Motion,quantummmotion.tech,QUANTUM,UK,2017,...
```

`quantummmotion.tech` has three m's and no NS record, so the README link
(`https://quantummmotion.tech`) is dead. The intended `quantummotion.tech` resolves and
301-redirects to `https://quantummotion.com/`, so I used the canonical `.com`. Happy to
use `quantummotion.tech` instead if you'd rather keep the minimal typo fix.

### Notes

- `README.md` regenerated with `python ./update.py` per the contributing steps. It
  produced no warnings, and the only changes are the two corresponding table rows.
- Unrelated but same class, if useful: `Beacon Photonics` has `beaconphotonics` as its
  website with no TLD, so that README link is broken too. The live site is
  `beaconphotonics.com`. Left it alone to keep this PR focused — glad to add it here or
  in a separate PR.

Found while surveying the list's careers pages, so these were verified against the live
sites rather than spotted by eye.
